### PR TITLE
CASMSEC-385-1: Update Makefile to work with :latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 CHART_METADATA_IMAGE ?= artifactory.algol60.net/csm-docker/stable/chart-metadata
 YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4
 HELM_IMAGE ?= artifactory.algol60.net/docker.io/alpine/helm:3.7.1
-HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/docker.io/quintush/helm-unittest
+HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/docker.io/quintush/helm-unittest:latest
 HELM_DOCS_IMAGE ?= artifactory.algol60.net/docker.io/jnorwood/helm-docs:v1.5.0
 
 all: lint dep-up test package
@@ -49,7 +49,7 @@ dep-up:
 test:
 	docker run --rm \
 		-v ${PWD}/charts:/apps \
-		${HELM_UNITTEST_IMAGE} -3 \
+		${HELM_UNITTEST_IMAGE} \
 		kyverno
 
 package:


### PR DESCRIPTION
## Summary and Scope

Update Makefile to work with :latest tag


This PR is related to https://github.com/Cray-HPE/cray-kyverno/pull/7 and CASMSEC-385 Jira.