### PR TITLE
CASMPET-6398: kyverno prevents weave-net daemonset from creating pods

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.3.1
+version: 1.3.2
 appVersion: v1.6.2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.5.0
+version: 1.3.1
 appVersion: v1.6.2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -38,3 +38,5 @@ kyverno:
   priorityClassName: csm-high-priority-service
  # Desired number of pods/replica
   replicaCount: 3
+  config:
+    webhooks: [{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno","kube-system"]}]}}]


### PR DESCRIPTION
## Summary and Scope

The daemonset-controller is not able to create the weave pod because it cannot get to kyverno to call the webhook.

## Testing



### Tested on:

Fanta

### Test description:

```
ncn-m001:~ # kubectl get pods -o wide -A | grep weave
kube-system         weave-net-25z8t                                                   2/2     Running     3          8h      1252.1.9     ncn-m002   <none>           <none>
kube-system         weave-net-44djx                                                   2/2     Running     1          6h5m    1252.1.12    ncn-w003   <none>           <none>
kube-system         weave-net-9m2gv                                                   2/2     Running     0          6h9m    1252.1.13    ncn-w002   <none>           <none>
kube-system         weave-net-h8zwh                                                   2/2     Running     3          8h      1252.1.8     ncn-m003   <none>           <none>
kube-system         weave-net-km476                                                   2/2     Running     3          5h4m    1252.1.10    ncn-m001   <none>           <none>
kube-system         weave-net-nnwbr                                                   2/2     Running     1          5h28m   1252.1.14    ncn-w001   <none>           <none>
kube-system         weave-net-q7h99                                                   2/2     Running     0          5h44m   1252.1.11    ncn-w004   <none>           <none>
ncn-m001:~ # kubectl rollout restart daemonset weave-net -n kube-system
daemonset.apps/weave-net restarted
ncn-m001:~ # kubectl get pods -o wide -A | grep weave
kube-system         weave-net-25z8t                                                   2/2     Running       3          8h     0.252.1.9     ncn-m002   <none>           <none>
kube-system         weave-net-44djx                                                   2/2     Running       1          6h11m  0.252.1.12    ncn-w003   <none>           <none>
kube-system         weave-net-9m2gv                                                   2/2     Running       0          6h15m  0.252.1.13    ncn-w002   <none>           <none>
kube-system         weave-net-h8zwh                                                   2/2     Running       3          8h     0.252.1.8     ncn-m003   <none>           <none>
kube-system         weave-net-km476                                                   2/2     Running       3          5h10m  0.252.1.10    ncn-m001   <none>           <none>
kube-system         weave-net-nnwbr                                                   2/2     Running       1          5h33m  0.252.1.14    ncn-w001   <none>           <none>
kube-system         weave-net-q7h99                                                   2/2     Terminating   0          5h49m  0.252.1.11    ncn-w004   <none>           <none>

ncn-m001:~ # kubectl get pods -o wide -A | grep weave
kube-system         weave-net-44djx                                                   2/2     Running       1          6h17m   10.252.1.12    ncn-w003   <none>           <none>
kube-system         weave-net-7pb47                                                   2/2     Running       0          2m21s   10.252.1.13    ncn-w002   <none>           <none>
kube-system         weave-net-9sq9g                                                   2/2     Running       0          3m18s   10.252.1.14    ncn-w001   <none>           <none>
kube-system         weave-net-h8zwh                                                   2/2     Running       3          8h      10.252.1.8     ncn-m003   <none>           <none>
kube-system         weave-net-km476                                                   0/2     Terminating   3          5h16m   10.252.1.10    ncn-m001   <none>           <none>
kube-system         weave-net-nnjv9                                                   2/2     Running       0          4m56s   10.252.1.11    ncn-w004   <none>           <none>
kube-system         weave-net-pf52t 

ncn-m001:~ # kubectl get pods -o wide -A | grep weave
kube-system         weave-net-44djx                                                   2/2     Running       1          6h37m   10.252.1.12    ncn-w003   <none>           <none>
kube-system         weave-net-7pb47                                                   2/2     Running       0          22m     10.252.1.13    ncn-w002   <none>           <none>
kube-system         weave-net-9sq9g                                                   2/2     Running       0          23m     10.252.1.14    ncn-w001   <none>           <none>
kube-system         weave-net-h8zwh                                                   2/2     Running       3          9h      10.252.1.8     ncn-m003   <none>           <none>
kube-system         weave-net-km476                                                   0/2     Terminating   3          5h36m   10.252.1.10    ncn-m001   <none>           <none>
kube-system         weave-net-nnjv9                                                   2/2     Running       0          25m     10.252.1.11    ncn-w004   <none>           <none>
kube-system         weave-net-pf52t                                                   2/2     Running       0          24m     10.252.1.9     ncn-m002   <none>           <none>
ncn-m001:~ #
                                                  2/2     Running       0          4m6s    10.252.1.9     ncn-m002   <none>           <none>
ncn-m001:~ # journalctl -u kubelet | grep webhook
.
.
.
pod="kube-system/weave-net-km476" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.29.194.64:443: connect: no route to host"
Mar 21 16:13:13 ncn-m001 kubelet[17533]: I0321 16:13:13.978535   17533 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-km476" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.29.194.64:443: connect: no route to host"
Mar 21 16:13:17 ncn-m001 kubelet[17533]: I0321 16:13:17.979734   17533 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-km476" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.29.194.64:443: connect: no route to host"
Mar 21 16:13:21 ncn-m001 kubelet[17533]: I0321 16:13:21.050583   17533 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-km476" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.29.194.64:443: connect: no route to host"
Mar 21 16:13:33 ncn-m001 kubelet[17533]: I0321 16:13:33.884468   17533 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-km476" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.29.194.64:443: connect: no route to host"

ncn-m001:~ # kubectl edit configmap cray-kyverno -n kyverno
configmap/cray-kyverno edited

ncn-m001:~ # kubectl get cm cray-kyverno -n kyverno -o yaml
apiVersion: v1
data:
  generateSuccessEvents: "false"
  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*]'
  webhooks: '[{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno","kube-system"]}]}}]'
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: cray-kyverno
    meta.helm.sh/release-namespace: kyverno
  creationTimestamp: "2023-03-21T05:39:01Z"
  labels:
    app: kyverno
    app.kubernetes.io/component: kyverno
    app.kubernetes.io/instance: cray-kyverno
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kyverno
    app.kubernetes.io/part-of: kyverno
    app.kubernetes.io/version: v2.3.3
    helm.sh/chart: kyverno-v2.3.3
  name: cray-kyverno
  namespace: kyverno
  resourceVersion: "1074390"
  uid: 35f7154b-2648-475d-b9d7-b0df879682df

ncn-m001:~ # kubectl rollout restart daemonset weave-net -n kube-system
daemonset.apps/weave-net restarted

ncn-m001:~ # kubectl scale deploy cray-kyverno -n kyverno --replicas 0
deployment.apps/cray-kyverno scaled

ncn-m001:~ # kubectl scale deploy cray-kyverno -n kyverno --replicas 3
deployment.apps/cray-kyverno scaled

ncn-m001:~ # kubectl get pods -o wide -A | grep weave
kube-system         weave-net-4c44p                                                   2/2     Running     0          4m46s   10.252.1.14    ncn-w001   <none>           <none>
kube-system         weave-net-dvmv2                                                   2/2     Running     0          98s     10.252.1.8     ncn-m003   <none>           <none>
kube-system         weave-net-fxxqn                                                   2/2     Running     0          51s     10.252.1.13    ncn-w002   <none>           <none>
kube-system         weave-net-h4nbp                                                   2/2     Running     0          6m33s   10.252.1.10    ncn-m001   <none>           <none>
kube-system         weave-net-knb55                                                   2/2     Running     0          3m59s   10.252.1.9     ncn-m002   <none>           <none>
kube-system         weave-net-lpqp8                                                   2/2     Running     0          2m56s   10.252.1.12    ncn-w003   <none>           <none>
kube-system         weave-net-nxghr                                                   2/2     Running     0          5m39s   10.252.1.11    ncn-w004   <none>           <none>
ncn-m001:~ #
ncn-m001:~ # journalctl -u kubelet | grep webhook
.
.
.
d" pod="kube-system/weave-net-g4t96" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.29.194.64:443: connect: no route to host"
Mar 21 17:21:32 ncn-m001 kubelet[17533]: I0321 17:21:32.190795   17533 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-g4t96" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.29.194.64:443: connect: no route to host"
ncn-m001:~ # date
Tue Mar 21 17:38:15 UTC 2023
```




