### PR TITLE
CASMPET-6438: (CSM 1.5/main) kyverno prevents weave-net daemonset from creating pods

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.5.0
+version: 1.5.1
 appVersion: v1.6.2
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -38,3 +38,5 @@ kyverno:
   priorityClassName: csm-high-priority-service
  # Desired number of pods/replica
   replicaCount: 3
+  config:
+    webhooks: [{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno","kube-system"]}]}}]


### PR DESCRIPTION
## Summary and Scope

The daemonset-controller is not able to create the weave pod because it cannot get to kyverno to call the webhook.

## Testing

Using username "root".
Authenticating with public key "ASIAPACIFIC\pradeepg@GIFXCRQH4H"

```
Last login: Thu Mar 23 06:06:45 2023 from 116.75.110.89
Welcome to the CRAY Pre-Install Toolkit (pit)
pit:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-4bg8f                                                   2/2     Running     1          4d15h   10.252.1.11   ncn-m002   <none>           <none>
kube-system      weave-net-4z9bq                                                   2/2     Running     1          4d15h   10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-8827d                                                   2/2     Running     1          4d15h   10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-9z7xg                                                   2/2     Running     1          4d15h   10.252.1.9    ncn-w003   <none>           <none>
kube-system      weave-net-g4hdg                                                   2/2     Running     1          4d15h   10.252.1.12   ncn-m003   <none>           <none>

pit:~ # journalctl -u kubelet | grep webhook


pit:~ # kubectl get cm cray-kyverno -n kyverno -o yaml
apiVersion: v1
data:
  generateSuccessEvents: "false"
  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*]'
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: cray-kyverno
    meta.helm.sh/release-namespace: kyverno
  creationTimestamp: "2023-03-18T15:42:02Z"
  labels:
    app: kyverno
    app.kubernetes.io/component: kyverno
    app.kubernetes.io/instance: cray-kyverno
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kyverno
    app.kubernetes.io/part-of: kyverno
    app.kubernetes.io/version: v2.3.3
    helm.sh/chart: kyverno-v2.3.3
  name: cray-kyverno
  namespace: kyverno
  resourceVersion: "6346"
  uid: 674ae0ef-2fd7-40d3-90dd-909ba6653a5d

pit:~ # kubectl rollout restart daemonset weave-net -n kube-system
daemonset.apps/weave-net restarted

pit:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-4bg8f                                                   2/2     Terminating   1          4d15h   10.252.1.11   ncn-m002   <none>           <none>
kube-system      weave-net-4z9bq                                                   2/2     Running       1          4d15h   10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-8827d                                                   2/2     Running       1          4d15h   10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-9z7xg                                                   2/2     Running       1          4d15h   10.252.1.9    ncn-w003   <none>           <none>
kube-system      weave-net-g4hdg                                                   2/2     Running       1          4d15h   10.252.1.12   ncn-m003   <none>           <none>

pit:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-4bg8f                                                   2/2     Terminating   1          4d15h   10.252.1.11   ncn-m002   <none>           <none>
kube-system      weave-net-4z9bq                                                   2/2     Running       1          4d15h   10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-8827d                                                   2/2     Running       1          4d15h   10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-9z7xg                                                   2/2     Running       1          4d15h   10.252.1.9    ncn-w003   <none>           <none>
kube-system      weave-net-g4hdg                                                   2/2     Running       1          4d15h   10.252.1.12   ncn-m003   <none>           <none>

ncn-m002:~ # journalctl -u kubelet | grep webhook
.
.
.
dial tcp 10.27.150.184:443: connect: no route to host"
Mar 23 06:57:50 ncn-m002 kubelet[14566]: I0323 06:57:50.177061   14566 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-4bg8f" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.27.150.184:443: connect: no route to host"
Mar 23 06:58:00 ncn-m002 kubelet[14566]: I0323 06:58:00.192644   14566 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-4bg8f" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.27.150.184:443: connect: no route to host"
Mar 23 06:58:10 ncn-m002 kubelet[14566]: I0323 06:58:10.176330   14566 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-4bg8f" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.27.150.184:443: connect: no route to host"
Mar 23 06:58:20 ncn-m002 kubelet[14566]: I0323 06:58:20.196592   14566 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-4bg8f" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.27.150.184:443: connect: no route to host"
ncn-m002:~ # date
Thu Mar 23 06:58:31 UTC 2023
ncn-m002:~ #

pit:~ # kubectl edit configmap cray-kyverno -n kyverno
configmap/cray-kyverno edited
pit:~ # kubectl get cm cray-kyverno -n kyverno -o yaml
apiVersion: v1
data:
  generateSuccessEvents: "false"
  resourceFilters: '[Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][*,kyverno,kyverno*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*]'
  webhooks: '[{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno","kube-system"]}]}}]'
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: cray-kyverno
    meta.helm.sh/release-namespace: kyverno
  creationTimestamp: "2023-03-18T15:42:02Z"
  labels:
    app: kyverno
    app.kubernetes.io/component: kyverno
    app.kubernetes.io/instance: cray-kyverno
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: kyverno
    app.kubernetes.io/part-of: kyverno
    app.kubernetes.io/version: v2.3.3
    helm.sh/chart: kyverno-v2.3.3
  name: cray-kyverno
  namespace: kyverno
  resourceVersion: "6587104"
  uid: 674ae0ef-2fd7-40d3-90dd-909ba6653a5d
pit:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-4z9bq                                                   2/2     Running       1          4d15h   10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-8827d                                                   2/2     Running       1          4d15h   10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-9z7xg                                                   2/2     Terminating   1          4d15h   10.252.1.9    ncn-w003   <none>           <none>
kube-system      weave-net-g4hdg                                                   2/2     Running       1          4d15h   10.252.1.12   ncn-m003   <none>           <none>
kube-system      weave-net-tdhcw                                                   2/2     Running       0          21s     10.252.1.11   ncn-m002   <none>           <none>
pit:~ #
pit:~ # kubectl get pods -o wide -A | grep weave
kube-system      weave-net-4d9fl                                                   2/2     Running     0          14s     10.252.1.8    ncn-w002   <none>           <none>
kube-system      weave-net-7l22n                                                   2/2     Running     0          106s    10.252.1.12   ncn-m003   <none>           <none>
kube-system      weave-net-c745b                                                   2/2     Running     0          2m32s   10.252.1.9    ncn-w003   <none>           <none>
kube-system      weave-net-nzmfh                                                   2/2     Running     0          58s     10.252.1.7    ncn-w001   <none>           <none>
kube-system      weave-net-tdhcw                                                   2/2     Running     0          3m25s   10.252.1.11   ncn-m002   <none>           <none>
pit:~ #
ncn-m002:~ # journalctl -u kubelet | grep webhook
.
.
.
dial tcp 10.27.150.184:443: connect: no route to host"
Mar 23 06:59:50 ncn-m002 kubelet[14566]: I0323 06:59:50.180983   14566 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-4bg8f" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.27.150.184:443: connect: no route to host"
Mar 23 07:00:00 ncn-m002 kubelet[14566]: I0323 07:00:00.192824   14566 status_manager.go:611] "Failed to delete status for pod" pod="kube-system/weave-net-4bg8f" err="Internal error occurred: failed calling webhook \"mutate.kyverno.svc-fail\": Post \"https://cray-kyverno-svc.kyverno.svc:443/mutate?timeout=10s\": dial tcp 10.27.150.184:443: connect: no route to host"


ncn-m002:~ # date
Thu Mar 23 07:05:04 UTC 2023
ncn-m002:~ #
```

### Tested on:

Dorian



