### PR TITLE
CASMSEC-397: Kyverno Upgrade Needed for N-2 Support Policy

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.5.1
-appVersion: v1.6.2
+version: 1.5.2
+appVersion: v1.7.5
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -13,7 +13,7 @@ keywords:
 dependencies:
   - name: kyverno
     repository: https://kyverno.github.io/kyverno/
-    version: v2.3.3
+    version: v2.5.5
 home: https://github.com/Cray-HPE/cray-kyverno
 sources:
   - https://github.com/kyverno/kyverno
@@ -25,9 +25,9 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/images: |-
     - name: kyverno
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.6.2
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5
     - name: kyvernopre
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.6.2
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5
     - name: busybox
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
   artifacthub.io/license: MIT

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -3,7 +3,7 @@
 kyverno:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno
-    tag: v1.6.2
+    tag: v1.7.5
   resources:
     limits:
       cpu: 6000m
@@ -14,7 +14,7 @@ kyverno:
   initImage:
     registry:
     repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre
-    tag: v1.6.2
+    tag: v1.7.5
   initResources:
     limits:
       cpu: 6000m
@@ -25,6 +25,8 @@ kyverno:
   testImage:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox
     tag: 1.28.0-glibc
+  securityContext:
+    seccompProfile: null
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:


### PR DESCRIPTION
## Summary and Scope

Changes performed to support Kyverno upgrade from 1.6.2 version to 1.7.5 version.

## Testing

```
ncn-m001:/tmp/pradeep # vi load.sh

ncn-m001:/tmp/pradeep # chmod +x load.sh

ncn-m001:/tmp/pradeep # sh -v load.sh
NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"
NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d)"

function load_container_algol() {
        export http_proxy=http://web-proxy.corp.hpecorp.net:8080
        export https_proxy=http://web-proxy.corp.hpecorp.net:8080
        export no_proxy="registry.local"
        echo "Loading container $1 from algol"
        podman run \
               --rm \
               --network host quay.io/skopeo/stable copy \
               --dest-tls-verify=false \
               --src-username "blah" \
               --src-password "blah \
               --dest-creds "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" \
               "docker://$1" "docker://registry.local/$1"
}

# Load required images
load_container_algol "artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5"
Loading container artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5 from algol
Getting image source signatures
Copying blob sha256:587bca4a1c2700b390816106b6b204c43fda111a42723318404d95f1167d37c3
Copying blob sha256:7073dd7f013c22dd18b7fdd5e3742f07a6da0e294f2c0b9d419337966aa624dd
Copying blob sha256:bd78102cec746a42fa5a1b53c403ca8bde8acb23c5fa0714a97cfbda8371d8a2
Copying config sha256:2d52b6aa2e43352b42ddaafbdb63c3abb82f200c0e1ff772489ceb16653347d9
Writing manifest to image destination
Storing signatures
load_container_algol "artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5"
Loading container artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5 from algol
Getting image source signatures
Copying blob sha256:0006f4d6d18d007a24d5d19bc769a6aeb8ab3deccc83a3d6374e12a2a555da98
Copying blob sha256:db6695d8d2d878f8b97608fddee5445d639b9810d4e8e4fa69ef408594fafba9
Copying config sha256:26064338f5636d28d828cf6105139725d05b34f06ace41d4dfa7dc201807dbfe
Writing manifest to image destination
Storing signatures

ncn-m001:/tmp/pradeep # helm upgrade -n kyverno cray-kyverno /tmp/pradeep/cray-kyverno-1.5.2.tgz --values ./cray-kyverno/values.yaml
Release "cray-kyverno" has been upgraded. Happy Helming!
NAME: cray-kyverno
LAST DEPLOYED: Tue Jun  6 04:18:01 2023
NAMESPACE: kyverno
STATUS: deployed
REVISION: 6
NOTES:
The official kyverno chart installed with some cray-specific overrides and defaults

ncn-m001:/tmp/pradeep # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         6               2023-06-06 04:18:01.752199718 +0000 UTC deployed        cray-kyverno-1.5.2                      v1.7.5
cray-kyverno-policies-upstream  kyverno         3               2023-06-01 16:49:04.077447754 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         3               2023-06-01 16:49:01.351112592 +0000 UTC deployed        kyverno-policy-1.4.1                    v1.6.0

ncn-m001:/tmp/pradeep # kubectl get pods -n kyverno
NAME                            READY   STATUS    RESTARTS   AGE
cray-kyverno-756b8f8497-7bqzg   1/1     Running   0          64s
cray-kyverno-756b8f8497-px229   1/1     Running   0          104s
cray-kyverno-756b8f8497-vqf8g   1/1     Running   0          104s

ncn-m001:/tmp/pradeep # kubectl get pol -A
NAMESPACE   NAME                                                BACKGROUND   ACTION   READY
dvs         pod-sec-ctxt-activemq-artemis-operator              true         audit    true
dvs         pod-sec-ctxt-dvs-mqtt                               true         audit    true
dvs         validate-pod-sec-ctxt-activemq-artemis-operator     true         audit    true
dvs         validate-pod-sec-ctxt-dvs-mqtt                      true         audit    true
services    pod-sec-ctxt-capmc                                  true         audit    true
services    pod-sec-ctxt-cfs-api                                true         audit    true
services    pod-sec-ctxt-console-data                           true         audit    true
services    pod-sec-ctxt-console-node                           true         audit    true
services    pod-sec-ctxt-console-operator                       true         audit    true
services    pod-sec-ctxt-cray-bos                               true         audit    true
services    pod-sec-ctxt-cray-bss                               true         audit    true
services    pod-sec-ctxt-cray-dns-powerdns                      true         audit    true
services    pod-sec-ctxt-cray-dns-unbound                       true         audit    true
services    pod-sec-ctxt-crus                                   true         audit    true
services    pod-sec-ctxt-customer-access-ingress                true         audit    true
services    pod-sec-ctxt-customer-high-speed                    true         audit    true
services    pod-sec-ctxt-customer-management-ingress            true         audit    true
services    pod-sec-ctxt-dhcp-kea                               true         audit    true
services    pod-sec-ctxt-fas                                    true         audit    true
services    pod-sec-ctxt-hbtd                                   true         audit    true
services    pod-sec-ctxt-hmnfd                                  true         audit    true
services    pod-sec-ctxt-ims                                    true         audit    true
services    pod-sec-ctxt-keycloak                               true         audit    true
services    pod-sec-ctxt-powerdns                               true         audit    true
services    pod-sec-ctxt-reds                                   true         audit    true
services    pod-sec-ctxt-scsd                                   true         audit    true
services    pod-sec-ctxt-sls                                    true         audit    true
services    pod-sec-ctxt-smd                                    true         audit    true
services    pod-sec-ctxt-sts                                    true         audit    true
services    pod-sec-ctxt-uas-mgr                                true         audit    true
services    validate-pod-sec-ctxt-capmc                         true         audit    true
services    validate-pod-sec-ctxt-cfs-api                       true         audit    true
services    validate-pod-sec-ctxt-console-data                  true         audit    true
services    validate-pod-sec-ctxt-console-node                  true         audit    true
services    validate-pod-sec-ctxt-console-operator              true         audit    true
services    validate-pod-sec-ctxt-cray-bos                      true         audit    true
services    validate-pod-sec-ctxt-cray-bss                      true         audit    true
services    validate-pod-sec-ctxt-cray-dns-powerdns             true         audit    true
services    validate-pod-sec-ctxt-cray-dns-unbound              true         audit    true
services    validate-pod-sec-ctxt-crus                          true         audit    true
services    validate-pod-sec-ctxt-customer-access-ingress       true         audit    true
services    validate-pod-sec-ctxt-customer-high-speed           true         audit    true
services    validate-pod-sec-ctxt-customer-management-ingress   true         audit    true
services    validate-pod-sec-ctxt-dhcp-kea                      true         audit    true
services    validate-pod-sec-ctxt-fas                           true         audit    true
services    validate-pod-sec-ctxt-hbtd                          true         audit    true
services    validate-pod-sec-ctxt-hmnfd                         true         audit    true
services    validate-pod-sec-ctxt-ims                           true         audit    true
services    validate-pod-sec-ctxt-keycloak                      true         audit    true
services    validate-pod-sec-ctxt-powerdns                      true         audit    true
services    validate-pod-sec-ctxt-reds                          true         audit    true
services    validate-pod-sec-ctxt-scsd                          true         audit    true
services    validate-pod-sec-ctxt-sls                           true         audit    true
services    validate-pod-sec-ctxt-smd                           true         audit    true
services    validate-pod-sec-ctxt-sts                           true         audit    true
services    validate-pod-sec-ctxt-uas-mgr                       true         audit    true
spire       pod-sec-ctxt-spire                                  true         audit    true
spire       pod-sec-ctxt-spire-server                           true         audit    true
spire       validate-pod-sec-ctxt-spire                         true         audit    true
spire       validate-pod-sec-ctxt-spire-server                  true         audit    true

ncn-m001:/tmp/pradeep # kubectl get cpol -A
NAME                             BACKGROUND   ACTION   READY
cluster-job-ttl                  true         audit    true
disallow-capabilities            true         audit    true
disallow-host-namespaces         true         audit    true
disallow-host-path               true         audit    true
disallow-host-ports              true         audit    true
disallow-host-process            true         audit    true
disallow-privileged-containers   true         audit    true
disallow-proc-mount              true         audit    true
disallow-selinux                 true         audit    true
restrict-apparmor-profiles       true         audit    true
restrict-seccomp                 true         audit    true
restrict-sysctls                 true         audit    true

ncn-m001:/tmp/pradeep # kubectl get polr -A
NAMESPACE           NAME                        PASS   FAIL   WARN   ERROR   SKIP   AGE
argo                polr-ns-argo                71     1      0      0       0      4d19h
ceph-cephfs         polr-ns-ceph-cephfs         18     6      0      0       0      4d19h
ceph-rbd            polr-ns-ceph-rbd            18     6      0      0       0      4d19h
cert-manager-init   polr-ns-cert-manager-init   0      0      0      0       0      4d19h
cert-manager        polr-ns-cert-manager        36     0      0      0       0      4d13h
hnc-system          polr-ns-hnc-system          12     0      0      0       0      4d19h
istio-operator      polr-ns-istio-operator      12     0      0      0       0      4d19h
istio-system        polr-ns-istio-system        72     0      0      0       0      4d19h
kyverno             polr-ns-kyverno             0      0      0      0       0      4d19h
metallb-system      polr-ns-metallb-system      21     3      0      0       0      4d19h
nexus               polr-ns-nexus               23     1      0      0       0      4d19h
opa                 polr-ns-opa                 48     0      0      0       0      4d19h
operators           polr-ns-operators           24     0      0      0       0      4d19h
pki-operator        polr-ns-pki-operator        12     0      0      0       0      4d19h
services            polr-ns-services            1250   12     0      0       0      4d19h
spire               polr-ns-spire               169    9      0      0       0      4d19h
sysmgmt-health      polr-ns-sysmgmt-health      126    6      0      0       0      4d19h
tapms-operator      polr-ns-tapms-operator      12     0      0      0       0      4d19h
user                polr-ns-user                0      0      0      0       0      4d18h
vault               polr-ns-vault               46     2      0      0       0      4d19h
velero              polr-ns-velero              23     1      0      0       0      4d19h


ncn-m001:/tmp/pradeep # helm rollback cray-kyverno 0 -n kyverno
Rollback was a success! Happy Helming!


ncn-m001:/tmp/pradeep # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         7               2023-06-06 06:31:37.596872004 +0000 UTC deployed        cray-kyverno-1.5.1                      v1.6.2
cray-kyverno-policies-upstream  kyverno         3               2023-06-01 16:49:04.077447754 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         3               2023-06-01 16:49:01.351112592 +0000 UTC deployed        kyverno-policy-1.4.1                    v1.6.0

ncn-m001:/tmp/pradeep # kubectl get pods -n kyverno
NAME                            READY   STATUS    RESTARTS   AGE
cray-kyverno-5589fc8d68-6dd9w   1/1     Running   0          2m12s
cray-kyverno-5589fc8d68-q9hhz   1/1     Running   0          2m12s
cray-kyverno-5589fc8d68-s8c7k   1/1     Running   0          72s
```
### Tested on:

DRAX

### Test description:

Performed Kyverno upgrade from from 1.6.2 version to 1.7.5 version on DRAX and sharing the logs.

