### PR TITLE
CASMSEC-397-1: Kyverno Upgrade Needed for N-2 Support Policy

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.4.1
-appVersion: v1.6.2
+version: 1.4.2
+appVersion: v1.7.5
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -13,7 +13,7 @@ keywords:
 dependencies:
   - name: kyverno
     repository: https://kyverno.github.io/kyverno/
-    version: v2.3.3
+    version: v2.5.5
 home: https://github.com/Cray-HPE/cray-kyverno
 sources:
   - https://github.com/kyverno/kyverno
@@ -25,9 +25,9 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/images: |-
     - name: kyverno
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.6.2
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5
     - name: kyvernopre
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.6.2
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5
     - name: busybox
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
   artifacthub.io/license: MIT

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -3,7 +3,7 @@
 kyverno:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno
-    tag: v1.6.2
+    tag: v1.7.5
   resources:
     limits:
       cpu: 6000m
@@ -14,7 +14,7 @@ kyverno:
   initImage:
     registry:
     repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre
-    tag: v1.6.2
+    tag: v1.7.5
   initResources:
     limits:
       cpu: 6000m
@@ -25,6 +25,8 @@ kyverno:
   testImage:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox
     tag: 1.28.0-glibc
+  securityContext:
+    seccompProfile: null
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:


### PR DESCRIPTION
## Summary and Scope

Changes performed to support Kyverno upgrade from 1.6.2 version to 1.7.5 version.

## Testing

```
ncn-m001:/tmp/pradeep/cray-kyverno # helm dependency update
Getting updates for unmanaged Helm repositories...

ncn-m001:/tmp/pradeep/cray-kyverno # helm dependency update
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://kyverno.github.io/kyverno/" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "algol60" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading kyverno from repo https://kyverno.github.io/kyverno/
Deleting outdated charts
ncn-m001:/tmp/pradeep/cray-kyverno #

ncn-m001:/tmp/pradeep # sh -v load.sh
#!/bin/bash



NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"
NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d)"

function load_container_algol() {
        echo "Loading container $1 from algol"
        podman run \
               --rm \
               --network host quay.io/skopeo/stable copy \
               --dest-tls-verify=false \
               --src-username "blah" \
               --src-password "blah" \
               --dest-creds "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" \
               "docker://$1" "docker://registry.local/$1"
}

# Load required images
load_container_algol "artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5"
Loading container artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5 from algol
Getting image source signatures
Copying blob sha256:0006f4d6d18d007a24d5d19bc769a6aeb8ab3deccc83a3d6374e12a2a555da98
Copying blob sha256:db6695d8d2d878f8b97608fddee5445d639b9810d4e8e4fa69ef408594fafba9
Copying config sha256:7205b98e1eaa6aed320f66c45c927bba8659c824c19b9192986b0e90a45ec7d4
Writing manifest to image destination
Storing signatures
ncn-m001:/tmp/pradeep # kubectl get pods -n kyverno^C
ncn-m001:/tmp/pradeep # vi load.sh
ncn-m001:/tmp/pradeep # sh -v load.sh
#!/bin/bash



NEXUS_USERNAME="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.username}} | base64 -d)"
NEXUS_PASSWORD="$(kubectl -n nexus get secret nexus-admin-credential --template {{.data.password}} | base64 -d)"

function load_container_algol() {
        echo "Loading container $1 from algol"
        podman run \
               --rm \
               --network host quay.io/skopeo/stable copy \
               --dest-tls-verify=false \
               --src-username "blah" \
               --src-password "blah" \
               --dest-creds "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" \
               "docker://$1" "docker://registry.local/$1"
}

# Load required images
load_container_algol "artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5"
Loading container artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5 from algol
Getting image source signatures
Copying blob sha256:587bca4a1c2700b390816106b6b204c43fda111a42723318404d95f1167d37c3
Copying blob sha256:7073dd7f013c22dd18b7fdd5e3742f07a6da0e294f2c0b9d419337966aa624dd
Copying blob sha256:bd78102cec746a42fa5a1b53c403ca8bde8acb23c5fa0714a97cfbda8371d8a2
Copying config sha256:3e03f2c6125a7052e063125d4a09fd3bc1f6bfadd04d74bb167e37bab9324846
Writing manifest to image destination
Storing signatures
ncn-m001:/tmp/pradeep # helm upgrade -n kyverno cray-kyverno /tmp/pradeep/cray-kyverno-1.4.2.tgz --values ./cray-kyverno/values.yaml
Release "cray-kyverno" has been upgraded. Happy Helming!
NAME: cray-kyverno
LAST DEPLOYED: Thu Jun  1 16:48:58 2023
NAMESPACE: kyverno
STATUS: deployed
REVISION: 53
NOTES:
The official kyverno chart installed with some cray-specific overrides and defaults
ncn-m001:/tmp/pradeep # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         53              2023-06-01 16:48:58.347028218 +0000 UTC deployed        cray-kyverno-1.4.2                      v1.7.5
cray-kyverno-policies-upstream  kyverno         3               2023-03-02 16:37:53.003221264 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         3               2023-03-02 16:37:48.274514882 +0000 UTC deployed        kyverno-policy-1.2.0                    v1.6.0
ncn-m001:/tmp/pradeep # 


ncn-m001:~ # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         53              2023-06-01 16:48:58.347028218 +0000 UTC deployed        cray-kyverno-1.4.2                      v1.7.5
cray-kyverno-policies-upstream  kyverno         3               2023-03-02 16:37:53.003221264 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         3               2023-03-02 16:37:48.274514882 +0000 UTC deployed        kyverno-policy-1.2.0                    v1.6.0
ncn-m001:/tmp/pradeep # kubectl get pods -n kyverno
NAME                            READY   STATUS    RESTARTS   AGE
cray-kyverno-756b8f8497-kcn98   1/1     Running   0          83s
cray-kyverno-756b8f8497-mnln9   1/1     Running   0          83s
cray-kyverno-756b8f8497-xmjm6   0/1     Running   0          33s
ncn-m001:/tmp/pradeep # kubectl get pol -A
NAMESPACE   NAME                                                BACKGROUND   ACTION   READY
services    pod-sec-ctxt-capmc                                  true         audit    true
services    pod-sec-ctxt-cfs-api                                true         audit    true
services    pod-sec-ctxt-console-data                           true         audit    true
services    pod-sec-ctxt-console-node                           true         audit    true
services    pod-sec-ctxt-console-operator                       true         audit    true
services    pod-sec-ctxt-cray-bos                               true         audit    true
services    pod-sec-ctxt-cray-bss                               true         audit    true
services    pod-sec-ctxt-cray-dns-powerdns                      true         audit    true
services    pod-sec-ctxt-cray-dns-unbound                       true         audit    true
services    pod-sec-ctxt-crus                                   true         audit    true
services    pod-sec-ctxt-customer-access-ingress                true         audit    true
services    pod-sec-ctxt-customer-high-speed                    true         audit    true
services    pod-sec-ctxt-customer-management-ingress            true         audit    true
services    pod-sec-ctxt-dhcp-kea                               true         audit    true
services    pod-sec-ctxt-fas                                    true         audit    true
services    pod-sec-ctxt-hbtd                                   true         audit    true
services    pod-sec-ctxt-hmnfd                                  true         audit    true
services    pod-sec-ctxt-ims                                    true         audit    true
services    pod-sec-ctxt-keycloak                               true         audit    true
services    pod-sec-ctxt-powerdns                               true         audit    true
services    pod-sec-ctxt-reds                                   true         audit    true
services    pod-sec-ctxt-scsd                                   true         audit    true
services    pod-sec-ctxt-sls                                    true         audit    true
services    pod-sec-ctxt-smd                                    true         audit    true
services    pod-sec-ctxt-sts                                    true         audit    true
services    pod-sec-ctxt-uas-mgr                                true         audit    true
services    validate-pod-sec-ctxt-capmc                         true         audit    true
services    validate-pod-sec-ctxt-cfs-api                       true         audit    true
services    validate-pod-sec-ctxt-console-data                  true         audit    true
services    validate-pod-sec-ctxt-console-node                  true         audit    true
services    validate-pod-sec-ctxt-console-operator              true         audit    true
services    validate-pod-sec-ctxt-cray-bos                      true         audit    true
services    validate-pod-sec-ctxt-cray-bss                      true         audit    true
services    validate-pod-sec-ctxt-cray-dns-powerdns             true         audit    true
services    validate-pod-sec-ctxt-cray-dns-unbound              true         audit    true
services    validate-pod-sec-ctxt-crus                          true         audit    true
services    validate-pod-sec-ctxt-customer-access-ingress       true         audit    true
services    validate-pod-sec-ctxt-customer-high-speed           true         audit    true
services    validate-pod-sec-ctxt-customer-management-ingress   true         audit    true
services    validate-pod-sec-ctxt-dhcp-kea                      true         audit    true
services    validate-pod-sec-ctxt-fas                           true         audit    true
services    validate-pod-sec-ctxt-hbtd                          true         audit    true
services    validate-pod-sec-ctxt-hmnfd                         true         audit    true
services    validate-pod-sec-ctxt-ims                           true         audit    true
services    validate-pod-sec-ctxt-keycloak                      true         audit    true
services    validate-pod-sec-ctxt-powerdns                      true         audit    true
services    validate-pod-sec-ctxt-reds                          true         audit    true
services    validate-pod-sec-ctxt-scsd                          true         audit    true
services    validate-pod-sec-ctxt-sls                           true         audit    true
services    validate-pod-sec-ctxt-smd                           true         audit    true
services    validate-pod-sec-ctxt-sts                           true         audit    true
services    validate-pod-sec-ctxt-uas-mgr                       true         audit    true
spire       pod-sec-ctxt-spire                                  true         audit    true
spire       pod-sec-ctxt-spire-server                           true         audit    true
spire       validate-pod-sec-ctxt-spire                         true         audit    true
spire       validate-pod-sec-ctxt-spire-server                  true         audit    true
ncn-m001:/tmp/pradeep # kubectl get polr -A
NAMESPACE        NAME                     PASS   FAIL   WARN   ERROR   SKIP   AGE
argo             polr-ns-argo             3      0      0      0       0      37h
ceph-cephfs      polr-ns-ceph-cephfs      2      1      0      0       0      37h
ceph-rbd         polr-ns-ceph-rbd         2      1      0      0       0      37h
cert-manager     polr-ns-cert-manager     3      0      0      0       0      37h
hnc-system       polr-ns-hnc-system       2      0      0      0       0      37h
ims              polr-ns-ims              20     0      0      0       0      37h
istio-operator   polr-ns-istio-operator   1      0      0      0       0      37h
istio-system     polr-ns-istio-system     6      0      0      0       0      37h
kyverno          polr-ns-kyverno          0      0      0      0       0      37h
local-volume     polr-ns-local-volume     2      0      0      0       0      37h
metallb-system   polr-ns-metallb-system   2      1      0      0       0      37h
nexus            polr-ns-nexus            3      0      0      0       0      37h
opa              polr-ns-opa              4      0      0      0       0      37h
operators        polr-ns-operators        6      0      0      0       0      37h
pki-operator     polr-ns-pki-operator     1      0      0      0       0      37h
services         polr-ns-services         307    8      0      0       0      37h
slurm-operator   polr-ns-slurm-operator   1      0      0      0       0      37h
sma              polr-ns-sma              38     0      0      0       0      37h
spire            polr-ns-spire            24     0      0      0       0      37h
sysmgmt-health   polr-ns-sysmgmt-health   13     0      0      0       0      37h
user             polr-ns-user             25     0      0      0       0      37h
vault            polr-ns-vault            3      0      0      0       0      37h
velero           polr-ns-velero           3      0      0      0       0      37h
ncn-m001:/tmp/pradeep # kubectl get cpol -A
NAME                             BACKGROUND   ACTION   READY
disallow-capabilities            true         audit    true
disallow-host-namespaces         true         audit    true
disallow-host-path               true         audit    true
disallow-host-ports              true         audit    true
disallow-host-process            true         audit    true
disallow-privileged-containers   true         audit    true
disallow-proc-mount              true         audit    true
disallow-selinux                 true         audit    true
restrict-apparmor-profiles       true         audit    true
restrict-seccomp                 true         audit    true
restrict-sysctls                 true         audit    true
ncn-m001:/tmp/pradeep # kubectl get pods -n kyverno
NAME                            READY   STATUS    RESTARTS   AGE
cray-kyverno-756b8f8497-kcn98   1/1     Running   0          3m15s
cray-kyverno-756b8f8497-mnln9   1/1     Running   0          3m15s
cray-kyverno-756b8f8497-xmjm6   1/1     Running   0          2m25s
ncn-m001:/tmp/pradeep # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         53              2023-06-01 16:48:58.347028218 +0000 UTC deployed        cray-kyverno-1.4.2                      v1.7.5
cray-kyverno-policies-upstream  kyverno         3               2023-03-02 16:37:53.003221264 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         3               2023-03-02 16:37:48.274514882 +0000 UTC deployed        kyverno-policy-1.2.0                    v1.6.0
ncn-m001:/tmp/pradeep # 
ncn-m001:~ # helm rollback cray-kyverno 0 -n kyverno
Rollback was a success! Happy Helming!
ncn-m001:~ # helm ls -n kyverno
NAME                            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
cray-kyverno                    kyverno         54              2023-06-06 08:36:53.5513969 +0000 UTC   deployed        cray-kyverno-1.4.0                      v1.6.2
cray-kyverno-policies-upstream  kyverno         3               2023-03-02 16:37:53.003221264 +0000 UTC deployed        cray-kyverno-policies-upstream-1.0.0    v1.6.2
kyverno-policy                  kyverno         3               2023-03-02 16:37:48.274514882 +0000 UTC deployed        kyverno-policy-1.2.0                    v1.6.0
ncn-m001:~ # 
ncn-m001:/tmp/pradeep # kubectl get pods -n kyverno
NAME                            READY   STATUS    RESTARTS   AGE
cray-kyverno-5589fc8d68-fj8j9   1/1     Running   0          34m
cray-kyverno-5589fc8d68-l5jvk   1/1     Running   0          33m
cray-kyverno-5589fc8d68-wjhrr   1/1     Running   0          34m
ncn-m001:/tmp/pradeep #
```

### Tested on:

MUG

### Test description:

Performed Kyverno upgrade from from 1.6.2 version to 1.7.5 version on MUG and sharing the logs.

