### PR TITLE
Security: Kyverno Upgrade Needed for 1.4.x to support N-2 Policy

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.4.2
+version: 1.4.3
 appVersion: v1.7.5
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -1,9 +1,9 @@
-{{/* vim: set filetype=mustache: */}}
-
-{{/* Expand the name of the chart. */}}
+{{/*
+Expand the name of the chart.
+*/}}
 {{- define "kyverno.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -23,10 +23,12 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
-{{/* Create chart name and version as used by the chart label. */}}
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
 {{- define "kyverno.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/* Helm required labels */}}
 {{- define "kyverno.labels" -}}
@@ -36,100 +38,28 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ template "kyverno.name" . }}
 app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
 app.kubernetes.io/version: "{{ .Chart.Version }}"
-helm.sh/chart: {{ template "kyverno.chart" . }}
-{{- if .Values.customLabels }}
-{{ toYaml .Values.customLabels }}
-{{- end }}
+helm.sh/chart: {{ include "kyverno.chart" . }}
 {{- end -}}
 
-{{/* Helm required labels */}}
-{{- define "kyverno.test-labels" -}}
-app.kubernetes.io/component: kyverno
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/name: {{ template "kyverno.name" . }}-test
-app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
-app.kubernetes.io/version: "{{ .Chart.Version }}"
-helm.sh/chart: {{ template "kyverno.chart" . }}
+{{/* Get deployed Kyverno version from Kubernetes */}}
+{{- define "kyverno.kyvernoVersion" -}}
+{{- $version := "" -}}
+{{- with (lookup "apps/v1" "Deployment" .Release.Namespace "kyverno") -}}
+  {{- with (first .spec.template.spec.containers) -}}
+    {{- $imageTag := (split ":" .image)._1 -}}
+    {{- $version = trimPrefix "v" $imageTag -}}
+  {{- end -}}
+{{- end -}}
+{{ $version }}
 {{- end -}}
 
-{{/* matchLabels */}}
-{{- define "kyverno.matchLabels" -}}
-app.kubernetes.io/name: {{ template "kyverno.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
-{{/* Get the config map name. */}}
-{{- define "kyverno.configMapName" -}}
-{{- printf "%s" (default (include "kyverno.fullname" .) .Values.config.existingConfig) -}}
-{{- end -}}
-
-{{/* Get the metrics config map name. */}}
-{{- define "kyverno.metricsConfigMapName" -}}
-{{- printf "%s" (default (printf "%s-metrics" (include "kyverno.fullname" .)) .Values.config.existingMetricsConfig) -}}
-{{- end -}}
-
-{{/* Get the namespace name. */}}
-{{- define "kyverno.namespace" -}}
-{{- if .Values.namespace -}}
-    {{- .Values.namespace -}}
-{{- else -}}
-    {{- .Release.Namespace -}}
+{{/* Fail if deployed Kyverno does not match */}}
+{{- define "kyverno.supportedKyvernoCheck" -}}
+{{- $supportedKyverno := index . "ver" -}}
+{{- $top := index . "top" }}
+{{- if (include "kyverno.kyvernoVersion" $top) -}}
+  {{- if not ( semverCompare $supportedKyverno (include "kyverno.kyvernoVersion" $top) ) -}}
+    {{- fail (printf "Kyverno version is too low, expected %s" $supportedKyverno) -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
-
-{{/* Create the name of the service to use */}}
-{{- define "kyverno.serviceName" -}}
-{{- printf "%s-svc" (include "kyverno.fullname" .) | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/* Create the name of the service account to use */}}
-{{- define "kyverno.serviceAccountName" -}}
-{{- if .Values.rbac.serviceAccount.create -}}
-    {{ default (include "kyverno.fullname" .) .Values.rbac.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.rbac.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{/* Create the default PodDisruptionBudget to use */}}
-{{- define "podDisruptionBudget.spec" -}}
-{{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
-{{- fail "Cannot set both .Values.podDisruptionBudget.minAvailable and .Values.podDisruptionBudget.maxUnavailable" -}}
-{{- end }}
-{{- if not .Values.podDisruptionBudget.maxUnavailable }}
-minAvailable: {{ default 1 .Values.podDisruptionBudget.minAvailable }}
-{{- end }}
-{{- if .Values.podDisruptionBudget.maxUnavailable }}
-maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
-{{- end }}
-{{- end }}
-
-{{- define "kyverno.securityContext" -}}
-{{ toYaml .Values.securityContext }}
-{{- end }}
-
-{{- define "kyverno.imagePullSecret" }}
-{{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" .registry (printf "%s:%s" .username .password | b64enc) | b64enc }}
-{{- end }}
-
-
-{{- define "kyverno.resourceFilters" -}}
-{{- $resourceFilters := .Values.config.resourceFilters }}
-{{- if .Values.excludeKyvernoNamespace }}
-  {{- $resourceFilters = prepend .Values.config.resourceFilters (printf "[*,%s,*]" (include "kyverno.namespace" .)) }}
-{{- end }}
-{{- tpl (join "" $resourceFilters) . }}
-{{- end }}
-
-{{- define "kyverno.webhooks" -}}
-{{- $excludeDefault := dict "key" "kubernetes.io/metadata.name" "operator" "NotIn" "values" (list (include "kyverno.namespace" .)) }}
-{{- $newWebhook := list }}
-{{- range $webhook := .Values.config.webhooks }}
-  {{- $namespaceSelector := default dict $webhook.namespaceSelector }}
-  {{- $matchExpressions := default list $namespaceSelector.matchExpressions }}
-  {{- $newNamespaceSelector := dict "matchLabels" $namespaceSelector.matchLabels "matchExpressions" (append $matchExpressions $excludeDefault) }}
-  {{- $newWebhook = append $newWebhook (merge (omit $webhook "namespaceSelector") (dict "namespaceSelector" $newNamespaceSelector)) }}
-{{- end }}
-{{- $newWebhook | toJson }}
-{{- end }}

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -1,0 +1,135 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Expand the name of the chart. */}}
+{{- define "kyverno.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kyverno.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "kyverno.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Helm required labels */}}
+{{- define "kyverno.labels" -}}
+app.kubernetes.io/component: kyverno
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "kyverno.name" . }}
+app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+helm.sh/chart: {{ template "kyverno.chart" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
+{{- end -}}
+
+{{/* Helm required labels */}}
+{{- define "kyverno.test-labels" -}}
+app.kubernetes.io/component: kyverno
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ template "kyverno.name" . }}-test
+app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
+app.kubernetes.io/version: "{{ .Chart.Version }}"
+helm.sh/chart: {{ template "kyverno.chart" . }}
+{{- end -}}
+
+{{/* matchLabels */}}
+{{- define "kyverno.matchLabels" -}}
+app.kubernetes.io/name: {{ template "kyverno.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/* Get the config map name. */}}
+{{- define "kyverno.configMapName" -}}
+{{- printf "%s" (default (include "kyverno.fullname" .) .Values.config.existingConfig) -}}
+{{- end -}}
+
+{{/* Get the metrics config map name. */}}
+{{- define "kyverno.metricsConfigMapName" -}}
+{{- printf "%s" (default (printf "%s-metrics" (include "kyverno.fullname" .)) .Values.config.existingMetricsConfig) -}}
+{{- end -}}
+
+{{/* Get the namespace name. */}}
+{{- define "kyverno.namespace" -}}
+{{- if .Values.namespace -}}
+    {{- .Values.namespace -}}
+{{- else -}}
+    {{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the name of the service to use */}}
+{{- define "kyverno.serviceName" -}}
+{{- printf "%s-svc" (include "kyverno.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.serviceAccountName" -}}
+{{- if .Values.rbac.serviceAccount.create -}}
+    {{ default (include "kyverno.fullname" .) .Values.rbac.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.rbac.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the default PodDisruptionBudget to use */}}
+{{- define "podDisruptionBudget.spec" -}}
+{{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
+{{- fail "Cannot set both .Values.podDisruptionBudget.minAvailable and .Values.podDisruptionBudget.maxUnavailable" -}}
+{{- end }}
+{{- if not .Values.podDisruptionBudget.maxUnavailable }}
+minAvailable: {{ default 1 .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+{{- end }}
+
+{{- define "kyverno.securityContext" -}}
+{{ toYaml .Values.securityContext }}
+{{- end }}
+
+{{- define "kyverno.imagePullSecret" }}
+{{- printf "{\"auths\":{\"%s\":{\"auth\":\"%s\"}}}" .registry (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+
+
+{{- define "kyverno.resourceFilters" -}}
+{{- $resourceFilters := .Values.config.resourceFilters }}
+{{- if .Values.excludeKyvernoNamespace }}
+  {{- $resourceFilters = prepend .Values.config.resourceFilters (printf "[*,%s,*]" (include "kyverno.namespace" .)) }}
+{{- end }}
+{{- tpl (join "" $resourceFilters) . }}
+{{- end }}
+
+{{- define "kyverno.webhooks" -}}
+{{- $excludeDefault := dict "key" "kubernetes.io/metadata.name" "operator" "NotIn" "values" (list (include "kyverno.namespace" .)) }}
+{{- $newWebhook := list }}
+{{- range $webhook := .Values.config.webhooks }}
+  {{- $namespaceSelector := default dict $webhook.namespaceSelector }}
+  {{- $matchExpressions := default list $namespaceSelector.matchExpressions }}
+  {{- $newNamespaceSelector := dict "matchLabels" $namespaceSelector.matchLabels "matchExpressions" (append $matchExpressions $excludeDefault) }}
+  {{- $newWebhook = append $newWebhook (merge (omit $webhook "namespaceSelector") (dict "namespaceSelector" $newNamespaceSelector)) }}
+{{- end }}
+{{- $newWebhook | toJson }}
+{{- end }}

--- a/charts/kyverno/templates/clusterrole.yaml
+++ b/charts/kyverno/templates/clusterrole.yaml
@@ -1,0 +1,36 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.fullname" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "kyverno.fullname" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/kyverno/templates/psp.yaml
+++ b/charts/kyverno/templates/psp.yaml
@@ -1,0 +1,53 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.fullname" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/psp.yaml
+++ b/charts/kyverno/templates/psp.yaml
@@ -26,7 +26,8 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ include "kyverno.fullname" . }}
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
 spec:
   supplementalGroups:
     ranges:

--- a/charts/kyverno/templates/rolebinding.yaml
+++ b/charts/kyverno/templates/rolebinding.yaml
@@ -1,0 +1,36 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.fullname" . }}-psp
+  labels: {{ include "kyverno.labels" . | nindent 4 }}
+    app: kyverno
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kyverno.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.fullname" . }}


### PR DESCRIPTION
Summary and Scope
Changes for Kyverno upgrade from version 1.6.2 to 1.7.5

Testing
Kyverno successfully upgraded from 1.6.2 to 1.7.5 version with introduction of new psp.

Tested on:
Mug

Test description:
Attached the test logs

https://github.com/Cray-HPE/cray-kyverno/files/11844590/KyvernoUpgradeTestLogs.txt