### PR TITLE
CASMSEC-402: Kyverno chart needs to handle a large amount of change requests during CSM upgrade

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.5.3
-appVersion: v1.7.5
+version: 1.5.4
+appVersion: v1.9.5
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -13,7 +13,7 @@ keywords:
 dependencies:
   - name: kyverno
     repository: https://kyverno.github.io/kyverno/
-    version: v2.5.5
+    version: v2.7.5
 home: https://github.com/Cray-HPE/cray-kyverno
 sources:
   - https://github.com/kyverno/kyverno
@@ -25,9 +25,9 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/images: |-
     - name: kyverno
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.7.5
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
     - name: kyvernopre
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.7.5
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
     - name: busybox
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
   artifacthub.io/license: MIT

--- a/charts/kyverno/templates/clusterrole.yaml
+++ b/charts/kyverno/templates/clusterrole.yaml
@@ -24,12 +24,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kyverno.fullname" . }}
+  name: {{ include "kyverno.fullname" . }}-psp
 rules:
 - apiGroups:
   - policy
   resourceNames:
-  - {{ include "kyverno.fullname" . }}
+  - {{ include "kyverno.fullname" . }}-psp
   resources:
   - podsecuritypolicies
   verbs:

--- a/charts/kyverno/templates/psp.yaml
+++ b/charts/kyverno/templates/psp.yaml
@@ -24,7 +24,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ include "kyverno.fullname" . }}
+  name: {{ include "kyverno.fullname" . }}-psp
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'

--- a/charts/kyverno/templates/rolebinding.yaml
+++ b/charts/kyverno/templates/rolebinding.yaml
@@ -24,12 +24,13 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kyverno.fullname" . }}-psp
+  name: {{ include "kyverno.fullname" . }}-psp-relocated
+  namespace: {{ include "kyverno.namespace" . | nindent 4 }}
   labels: {{ include "kyverno.labels" . | nindent 4 }}
     app: kyverno
 roleRef:
   kind: ClusterRole
-  name: {{ include "kyverno.fullname" . }}
+  name: {{ include "kyverno.fullname" . }}-psp
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/charts/kyverno/templates/rolebinding.yaml
+++ b/charts/kyverno/templates/rolebinding.yaml
@@ -25,7 +25,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "kyverno.fullname" . }}-psp-relocated
-  namespace: {{ include "kyverno.namespace" . | nindent 4 }}
   labels: {{ include "kyverno.labels" . | nindent 4 }}
     app: kyverno
 roleRef:

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -3,7 +3,7 @@
 kyverno:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno
-    tag: v1.7.5
+    tag: v1.9.5
   resources:
     limits:
       cpu: 6000m
@@ -14,7 +14,7 @@ kyverno:
   initImage:
     registry:
     repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre
-    tag: v1.7.5
+    tag: v1.9.5
   initResources:
     limits:
       cpu: 6000m


### PR DESCRIPTION
## Summary and Scope

Kyverno chart needs to handle a large amount of change requests during CSM upgrade. Upgrading kyverno from version 1.7.5 to 1.9.5.

## Testing

Performed upgrade testing along with policy, policy report and cluster policy check.
Attaching logs here.
[kyverno_upgrade_logs_175_to_195.txt](https://github.com/Cray-HPE/cray-kyverno/files/12744430/kyverno_upgrade_logs_175_to_195.txt)

### Tested on:

MUG

### Test description:

Upgrade testing.

