### PR TITLE
CASMSEC-402-1: Kyverno chart needs to handle a large amount of change requests during CSM upgrade

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -28,6 +28,8 @@ annotations:
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
     - name: kyvernopre
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
+    - name: cleanupController
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5
     - name: busybox
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
   artifacthub.io/license: MIT

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.5.4
+version: 1.5.5
 appVersion: v1.9.5
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/cleanup-controller/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup-controller/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.cleanup-controller.name" -}}
+{{ template "kyverno.name" . }}-cleanup-controller
+{{- end -}}
+
+{{- define "kyverno.cleanup-controller.labels" -}}
+app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
+{{- with (include "kyverno.helmLabels" .) }}
+{{ . }}
+{{- end }}
+{{- with (include "kyverno.versionLabels" .) }}
+{{ . }}
+{{- end }}
+{{- with (include "kyverno.cleanup-controller.matchLabels" .) }}
+{{ . }}
+{{- end }}
+{{- end -}}
+
+{{- define "kyverno.cleanup-controller.matchLabels" -}}
+app.kubernetes.io/component: cleanup-controller
+app.kubernetes.io/name: {{ template "kyverno.cleanup-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "kyverno.cleanup-controller.image" -}}
+{{- if .image.registry -}}
+  {{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- else -}}
+  {{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.cleanup-controller.sAccountName" -}}
+{{- if .Values.kyverno.cleanupController.rbac.create -}}
+    {{ default (include "kyverno.cleanup-controller.name" .) .Values.kyverno.cleanupController.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.cleanupController.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.kyverno.cleanupController.enabled -}}
+{{- if .Values.kyverno.cleanupController.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.cleanup-controller.name" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "kyverno.cleanup-controller.name" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+{{- end }}
+{{- end }}

--- a/charts/kyverno/templates/cleanup-controller/psp.yaml
+++ b/charts/kyverno/templates/cleanup-controller/psp.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.cleanup-controller.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/cleanup-controller/rolebinding.yaml
+++ b/charts/kyverno/templates/cleanup-controller/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.kyverno.cleanupController.enabled -}}
+{{- if .Values.kyverno.cleanupController.rbac.create -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.cleanup-controller.name" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.cleanup-controller.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.cleanup-controller.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+{{- end }}
+{{- end }}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -29,6 +29,7 @@ kyverno:
     seccompProfile: null
   cleanupController:
     # -- Disable cleanup controller since it is not production ready.
+    # -- If cleanup controller is enabled then need to enable rbac as well
     enabled: false
     rbac:
       create: false

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -30,6 +30,9 @@ kyverno:
   cleanupController:
     # -- Disable cleanup controller since it is not production ready.
     enabled: false
+    image:
+      repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller
+      tag: v1.9.5
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -30,6 +30,10 @@ kyverno:
   cleanupController:
     # -- Disable cleanup controller since it is not production ready.
     enabled: false
+    rbac:
+      create: false
+      saccount:
+        name: kyverno-cleanup-controller
     image:
       repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller
       tag: v1.9.5

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -27,6 +27,9 @@ kyverno:
     tag: 1.28.0-glibc
   securityContext:
     seccompProfile: null
+  cleanupController:
+    # -- Disable cleanup controller since it is not production ready.
+    enabled: false
   podAntiAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       - labelSelector:


### PR DESCRIPTION
## Summary and Scope

As part kyverno upgrade to 1.9.5 the cleanup-controller feature is disabled as this is still not production ready and might break break normal functioning of kyverno. Hence submitting this change.

## Testing

Upgrade testing.

### Tested on:

MUG

### Test description:

Upgrade testing logs.
[Kyverno_upgrade_testing_log_cleanup_ftr_fix.txt](https://github.com/Cray-HPE/cray-kyverno/files/12818185/Kyverno_upgrade_testing_log_cleanup_ftr_fix.txt)

