### PR TITLE
CASM-4820: KYVERNO chart upgrade needed for CSM version 1.6.x

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.0
-appVersion: v1.9.5
+version: 1.6.1
+appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
 keywords:
@@ -13,7 +13,7 @@ keywords:
 dependencies:
   - name: kyverno
     repository: https://kyverno.github.io/kyverno/
-    version: v2.7.5
+    version: v3.0.9
 home: https://github.com/Cray-HPE/cray-kyverno
 sources:
   - https://github.com/kyverno/kyverno
@@ -25,11 +25,15 @@ kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/images: |-
     - name: kyverno
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.9.5
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.10.7
     - name: kyvernopre
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.9.5
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.10.7
     - name: cleanupController
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.9.5      
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.10.7
+    - name: reportsController
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.10.7    
+    - name: backgroundController
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.10.7          
     - name: busybox
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox:1.28.0-glibc
   artifacthub.io/license: MIT

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.1
+version: 1.6.2
 appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/_helpers.tpl
+++ b/charts/kyverno/templates/_helpers.tpl
@@ -5,6 +5,10 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "kyverno.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/kyverno/templates/admission-controller/_helpers.tpl
+++ b/charts/kyverno/templates/admission-controller/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.admission-controller.name" -}}
+{{ template "kyverno.name" . }}-admission-controller
+{{- end -}}
+
+{{- define "kyverno.admission-controller.image" -}}
+{{- if .image.registry -}}
+  {{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- else -}}
+  {{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.admission-controller.sAccountName" -}}
+{{- if .Values.kyverno.admissionController.rbac.create -}}
+    {{ default (include "kyverno.admission-controller.name" .) .Values.kyverno.admissionController.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.admissionController.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/admission-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/admission-controller/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.admission-controller.name" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "kyverno.admission-controller.name" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/kyverno/templates/admission-controller/psp.yaml
+++ b/charts/kyverno/templates/admission-controller/psp.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.admission-controller.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/admission-controller/rolebinding.yaml
+++ b/charts/kyverno/templates/admission-controller/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.admission-controller.name" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.admission-controller.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.admission-controller.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}

--- a/charts/kyverno/templates/background-controller/_helpers.tpl
+++ b/charts/kyverno/templates/background-controller/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.background-controller.name" -}}
+{{ template "kyverno.name" . }}-background-controller
+{{- end -}}
+
+{{- define "kyverno.background-controller.image" -}}
+{{- if .image.registry -}}
+  {{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- else -}}
+  {{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.background-controller.sAccountName" -}}
+{{- if .Values.kyverno.backgroundController.rbac.create -}}
+    {{ default (include "kyverno.background-controller.name" .) .Values.kyverno.backgroundController.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.backgroundController.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/background-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/background-controller/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.background-controller.name" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "kyverno.background-controller.name" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/kyverno/templates/background-controller/psp.yaml
+++ b/charts/kyverno/templates/background-controller/psp.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.background-controller.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/background-controller/rolebinding.yaml
+++ b/charts/kyverno/templates/background-controller/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.background-controller.name" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.background-controller.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.background-controller.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}

--- a/charts/kyverno/templates/cleanup-admission-reports/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup-admission-reports/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.cleanup-admission-reports.name" -}}
+{{ template "kyverno.name" . }}-cleanup-admission-reports
+{{- end -}}
+
+{{- define "kyverno.cleanup-admission-reports.image" -}}
+{{- if .image.registry -}}
+  {{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- else -}}
+  {{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.cleanup-admission-reports.sAccountName" -}}
+{{- if .Values.kyverno.cleanupJobs.admissionReports.rbac.create -}}
+    {{ default (include "kyverno.cleanup-admission-reports.name" .) .Values.kyverno.cleanupJobs.admissionReports.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.cleanupJobs.admissionReports.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/cleanup-admission-reports/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-admission-reports/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.cleanup-admission-reports.name" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "kyverno.cleanup-admission-reports.name" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/kyverno/templates/cleanup-admission-reports/psp.yaml
+++ b/charts/kyverno/templates/cleanup-admission-reports/psp.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.cleanup-admission-reports.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/cleanup-admission-reports/rolebinding.yaml
+++ b/charts/kyverno/templates/cleanup-admission-reports/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.cleanup-admission-reports.name" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.cleanup-admission-reports.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.cleanup-admission-reports.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}

--- a/charts/kyverno/templates/cleanup-cluster-admission-reports/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup-cluster-admission-reports/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.cleanup-cluster-admission-reports.name" -}}
+{{ template "kyverno.name" . }}-cleanup-cluster-admission-reports
+{{- end -}}
+
+{{- define "kyverno.cleanup-cluster-admission-reports.image" -}}
+{{- if .image.registry -}}
+  {{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- else -}}
+  {{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.cleanup-cluster-admission-reports.sAccountName" -}}
+{{- if .Values.kyverno.cleanupJobs.clusterAdmissionReports.rbac.create -}}
+    {{ default (include "kyverno.cleanup-cluster-admission-reports.name" .) .Values.kyverno.cleanupJobs.clusterAdmissionReports.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.cleanupJobs.clusterAdmissionReports.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/cleanup-cluster-admission-reports/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-cluster-admission-reports/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.cleanup-cluster-admission-reports.name" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "kyverno.cleanup-cluster-admission-reports.name" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/kyverno/templates/cleanup-cluster-admission-reports/psp.yaml
+++ b/charts/kyverno/templates/cleanup-cluster-admission-reports/psp.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.cleanup-cluster-admission-reports.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/cleanup-cluster-admission-reports/rolebinding.yaml
+++ b/charts/kyverno/templates/cleanup-cluster-admission-reports/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.cleanup-cluster-admission-reports.name" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.cleanup-cluster-admission-reports.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.cleanup-cluster-admission-reports.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}

--- a/charts/kyverno/templates/cleanup-controller/_helpers.tpl
+++ b/charts/kyverno/templates/cleanup-controller/_helpers.tpl
@@ -4,25 +4,6 @@
 {{ template "kyverno.name" . }}-cleanup-controller
 {{- end -}}
 
-{{- define "kyverno.cleanup-controller.labels" -}}
-app.kubernetes.io/part-of: {{ template "kyverno.name" . }}
-{{- with (include "kyverno.helmLabels" .) }}
-{{ . }}
-{{- end }}
-{{- with (include "kyverno.versionLabels" .) }}
-{{ . }}
-{{- end }}
-{{- with (include "kyverno.cleanup-controller.matchLabels" .) }}
-{{ . }}
-{{- end }}
-{{- end -}}
-
-{{- define "kyverno.cleanup-controller.matchLabels" -}}
-app.kubernetes.io/component: cleanup-controller
-app.kubernetes.io/name: {{ template "kyverno.cleanup-controller.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
-
 {{- define "kyverno.cleanup-controller.image" -}}
 {{- if .image.registry -}}
   {{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}

--- a/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/cleanup-controller/clusterrole.yaml
@@ -1,5 +1,3 @@
-{{- if .Values.kyverno.cleanupController.enabled -}}
-{{- if .Values.kyverno.cleanupController.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -13,5 +11,3 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
-{{- end }}
-{{- end }}

--- a/charts/kyverno/templates/cleanup-controller/psp.yaml
+++ b/charts/kyverno/templates/cleanup-controller/psp.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/charts/kyverno/templates/cleanup-controller/rolebinding.yaml
+++ b/charts/kyverno/templates/cleanup-controller/rolebinding.yaml
@@ -1,5 +1,3 @@
-{{- if .Values.kyverno.cleanupController.enabled -}}
-{{- if .Values.kyverno.cleanupController.rbac.create -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,5 +11,3 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "kyverno.cleanup-controller.sAccountName" . }}
   namespace: {{ template "kyverno.namespace" . }}
-{{- end }}
-{{- end }}

--- a/charts/kyverno/templates/clusterrole.yaml
+++ b/charts/kyverno/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/charts/kyverno/templates/psp.yaml
+++ b/charts/kyverno/templates/psp.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/charts/kyverno/templates/reports-controller/_helpers.tpl
+++ b/charts/kyverno/templates/reports-controller/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.reports-controller.name" -}}
+{{ template "kyverno.name" . }}-reports-controller
+{{- end -}}
+
+{{- define "kyverno.reports-controller.image" -}}
+{{- if .image.registry -}}
+  {{ .image.registry }}/{{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- else -}}
+  {{ required "An image repository is required" .image.repository }}:{{ default .defaultTag .image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.reports-controller.sAccountName" -}}
+{{- if .Values.kyverno.reportsController.rbac.create -}}
+    {{ default (include "kyverno.reports-controller.name" .) .Values.kyverno.reportsController.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.reportsController.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/reports-controller/clusterrole.yaml
+++ b/charts/kyverno/templates/reports-controller/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.reports-controller.name" . }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "kyverno.reports-controller.name" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/kyverno/templates/reports-controller/psp.yaml
+++ b/charts/kyverno/templates/reports-controller/psp.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.reports-controller.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/reports-controller/rolebinding.yaml
+++ b/charts/kyverno/templates/reports-controller/rolebinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.reports-controller.name" . }}
+  namespace: {{ template "kyverno.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.reports-controller.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.reports-controller.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}

--- a/charts/kyverno/templates/rolebinding.yaml
+++ b/charts/kyverno/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -13,7 +13,8 @@ kyverno:
       webhooks: [{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system"]}]}}]
     initContainer:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre
+        registry: artifactory.algol60.net
+        repository: csm-docker/stable/ghcr.io/kyverno/kyvernopre
         tag: v1.10.7
       resources:
         limits:
@@ -24,7 +25,8 @@ kyverno:
           memory: 1Gi
     container:
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno
+        registry: artifactory.algol60.net
+        repository: csm-docker/stable/ghcr.io/kyverno/kyverno
         tag: v1.10.7
       resources:
         limits:
@@ -57,7 +59,8 @@ kyverno:
       saccount:
         name: kyverno-cleanup-controller
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/ghcr.io/kyverno/cleanup-controller
       tag: v1.10.7
     resources:
       limits:
@@ -72,7 +75,8 @@ kyverno:
       saccount:
         name: kyverno-reports-controller
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/ghcr.io/kyverno/reports-controller
       tag: v1.10.7
     resources:
       limits:
@@ -87,7 +91,8 @@ kyverno:
       saccount:
         name: kyverno-background-controller
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/ghcr.io/kyverno/background-controller
       tag: v1.10.7
     resources:
       limits:
@@ -103,7 +108,8 @@ kyverno:
         saccount:
           name: kyverno-cleanup-jobs
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+        registry: artifactory.algol60.net
+        repository: csm-docker/stable/docker.io/bitnami/kubectl
         tag: 1.26.4
     clusterAdmissionReports:
       rbac:
@@ -111,7 +117,8 @@ kyverno:
         saccount:
           name: kyverno-cleanup-jobs
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+        registry: artifactory.algol60.net
+        repository: csm-docker/stable/docker.io/bitnami/kubectl
         tag: 1.26.4
   webhooksCleanup:
     image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -1,55 +1,120 @@
 # Default values for cray-kyverno.
 # This is a YAML-formatted file.
 kyverno:
-  image:
-    repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno
-    tag: v1.9.5
-  resources:
-    limits:
-      cpu: 6000m
-      memory: 3Gi
-    requests:
-      cpu: 2000m
-      memory: 1Gi
-  initImage:
-    registry:
-    repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre
-    tag: v1.9.5
-  initResources:
-    limits:
-      cpu: 6000m
-      memory: 3Gi
-    requests:
-      cpu: 2000m
-      memory: 1Gi
-  testImage:
-    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox
-    tag: 1.28.0-glibc
-  securityContext:
-    seccompProfile: null
-  cleanupController:
-    # -- Disable cleanup controller since it is not production ready.
-    # -- If cleanup controller is enabled then need to enable rbac as well
-    enabled: false
+  upgrade:
+  # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
+    fromV2: true
+  admissionController:
     rbac:
-      create: false
+      create: true
+      saccount:
+        name: kyverno-admission-controller
+    config:
+      webhooks: [{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kube-system"]}]}}]
+    initContainer:
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre
+        tag: v1.10.7
+      resources:
+        limits:
+          cpu: 6000m
+          memory: 3Gi
+        requests:
+          cpu: 2000m
+          memory: 1Gi
+    container:
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno
+        tag: v1.10.7
+      resources:
+        limits:
+          cpu: 6000m
+          memory: 3Gi
+        requests:
+          cpu: 2000m
+          memory: 1Gi
+    # Desired number of pods/replica
+    replicas: 3
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - kyverno
+          topologyKey: kubernetes.io/hostname
+
+    priorityClassName: csm-high-priority-service
+
+  test:
+    image:
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/busybox
+      tag: 1.28.0-glibc
+  cleanupController:
+    rbac:
+      create: true
       saccount:
         name: kyverno-cleanup-controller
     image:
       repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller
-      tag: v1.9.5    
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app.kubernetes.io/name
-            operator: In
-            values:
-            - kyverno
-        topologyKey: kubernetes.io/hostname
+      tag: v1.10.7
+    resources:
+      limits:
+        cpu: 6000m
+        memory: 3Gi
+      requests:
+        cpu: 2000m
+        memory: 1Gi
+  reportsController:
+    rbac:
+      create: true
+      saccount:
+        name: kyverno-reports-controller
+    image:
+      repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller
+      tag: v1.10.7
+    resources:
+      limits:
+        cpu: 6000m
+        memory: 3Gi
+      requests:
+        cpu: 2000m
+        memory: 1Gi
+  backgroundController:
+    rbac:
+      create: true
+      saccount:
+        name: kyverno-background-controller
+    image:
+      repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller
+      tag: v1.10.7
+    resources:
+      limits:
+        cpu: 6000m
+        memory: 3Gi
+      requests:
+        cpu: 2000m
+        memory: 1Gi
+  cleanupJobs:
+    admissionReports:
+      rbac:
+        create: true
+        saccount:
+          name: kyverno-cleanup-jobs
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+        tag: 1.26.4
+    clusterAdmissionReports:
+      rbac:
+        create: true
+        saccount:
+          name: kyverno-cleanup-jobs
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+        tag: 1.26.4
+  webhooksCleanup:
+    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4
 
-  priorityClassName: csm-high-priority-service
- # Desired number of pods/replica
-  replicaCount: 3
-  config:
-    webhooks: [{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno","kube-system"]}]}}]
+  securityContext:
+    seccompProfile: null


### PR DESCRIPTION
## Summary and Scope

To support N-2 version policy upgrading the current version of Kyverno 1.9.5 to 1.10.7 version. This will resolve some of the outstanding issues as well.

## Testing

Install, upgrade, rollback, policy and cluster policy listing, policy report.

### Tested on:

Surtur

### Test description:

[KyvernoLogs1.6.2artiChart.txt](https://github.com/user-attachments/files/16687380/KyvernoLogs1.6.2artiChart.txt)

