### PR TITLE
CASM-4818: Creation of post install hook for Kyverno deployment to enable trust between Kyverno and Nexus

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.2
+version: 1.6.3
 appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/build-kyverno-trust/_helper.tpl
+++ b/charts/kyverno/templates/build-kyverno-trust/_helper.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.post-install-job.name" -}}
+{{ template "kyverno.name" . }}-post-install-job
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.post-install-job.sAccountName" -}}
+{{- if .Values.kyverno.buildKyvernoTrust.rbac.create -}}
+    {{ default (include "kyverno.post-install-job.name" .) .Values.kyverno.buildKyvernoTrust.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.buildKyvernoTrust.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kyverno.post-install-job.name" . }}
+  labels:
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": post-upgrade,post-install
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+    spec:
+      restartPolicy: Never
+      serviceAccount: {{ template "kyverno.post-install-job.sAccountName" . }}
+      containers:
+        - name: {{ template "kyverno.post-install-job.name" . }}
+          image: {{ .Values.kyverno.buildKyvernoTrust.image.registry }}/{{ .Values.kyverno.buildKyvernoTrust.image.repository }}:{{ .Values.kyverno.buildKyvernoTrust.image.tag }}
+          command:
+            - '/bin/sh'
+          args:
+            - '-c'
+            - 'cd /usr/local/sbin && sh build-trust.sh '
+          volumeMounts:
+          - mountPath: /usr/local/sbin
+            name: build-kyverno-trust
+          - mountPath: /mnt/platform
+            name: host-path1
+          - mountPath: /mnt/ca
+            name: host-path2
+          securityContext:
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+      volumes:
+      - name: build-kyverno-trust
+        configMap:
+          name: build-kyverno-trust
+          defaultMode: 0755
+      - name: host-path1
+        hostPath:
+          path: /etc/pki/trust/anchors
+      - name: host-path2
+        hostPath:
+          path: /etc/kubernetes/pki

--- a/charts/kyverno/templates/build-kyverno-trust/clusterrole.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.post-install-job.name" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-10"
+rules:
+- apiGroups: [""]
+  resourceNames:
+  - {{ include "kyverno.post-install-job.name" . }}
+  resources: [podsecuritypolicies]
+  verbs: [get, list, patch, create, delete, use]
+- apiGroups: [""]
+  resources: [configmaps]
+  verbs: [get, list, patch, create, delete]
+- apiGroups: ["apps"]
+  resources: [deployments]
+  verbs: [get, list, patch, create, delete]
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [list, get, delete,create]

--- a/charts/kyverno/templates/build-kyverno-trust/clusterrolebining.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/clusterrolebining.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.post-install-job.name" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.post-install-job.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.post-install-job.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}

--- a/charts/kyverno/templates/build-kyverno-trust/configmap.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/configmap.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-kyverno-trust
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+data:
+  build-trust.sh: |-
+    #!/bin/bash
+    CERT_PATH1="/mnt/platform/platform-ca-certs.crt"
+    CERT_PATH2="/mnt/ca/ca.crt"
+    cat "$CERT_PATH1" "$CERT_PATH2" > /tmp/combined-certs.crt
+    kubectl create configmap kyverno-certs --from-file=ca-certificates=/tmp/combined-certs.crt --namespace=kyverno --dry-run=client -o yaml | kubectl apply -f -
+    kubectl patch deployment kyverno-admission-controller -n kyverno --type=json -p='[
+      {
+        "op": "add",
+        "path": "/spec/template/spec/volumes",
+        "value": [
+          {
+            "name": "sigstore"
+          },
+          {
+            "name": "ca-certificates",
+            "configMap": {
+              "name": "kyverno-certs",
+              "items": [
+                {
+                  "key": "ca-certificates",
+                  "path": "ca-certificates.crt"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "op": "add",
+        "path": "/spec/template/spec/containers/0/volumeMounts",
+        "value": [
+          {
+            "mountPath": "/.sigstore",
+            "name": "sigstore"
+          },
+          {
+            "name": "ca-certificates",
+            "mountPath": "/etc/ssl/certs/ca-certificates.crt",
+            "subPath": "ca-certificates.crt"
+          }
+        ]
+      }
+    ]'

--- a/charts/kyverno/templates/build-kyverno-trust/post-install-job-svc-account.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/post-install-job-svc-account.yaml
@@ -1,0 +1,7 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "kyverno.post-install-job.sAccountName" . }}
+  annotations:
+    "helm.sh/hook": post-upgrade,post-install
+    "helm.sh/hook-weight": "-20"

--- a/charts/kyverno/templates/build-kyverno-trust/psp.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/psp.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kyverno.post-install-job.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+spec:
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+  - flexVolume

--- a/charts/kyverno/templates/build-kyverno-trust/psp.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/psp.yaml
@@ -29,3 +29,4 @@ spec:
   - persistentVolumeClaim
   - hostPath
   - flexVolume
+  

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -122,6 +122,15 @@ kyverno:
         tag: 1.26.4
   webhooksCleanup:
     image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4
-
+  buildKyvernoTrust:
+    rbac:
+      create: true
+      saccount:
+        name: post-install-job
+    image:
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/docker.io/bitnami/kubectl
+      tag: 1.26.4
+      
   securityContext:
     seccompProfile: null


### PR DESCRIPTION
## Summary and Scope

The changes with this PR will enable trust between Kyverno and Nexus for container image verification.

## Testing

Kyverno trust build and postinstall hook verification.

Below mentioned 4 scenarios are verified successfully:
1] cray-kyverno 1.6.0 to 1.6.3 version upgrade and rollback
2] cray-kyverno 1.6.3 version Fresh install
3] cray-kyverno 1.6.3 to 1.6.4 version upgrade and rollback
4] cray-kyverno 1.5.5 to 1.6.3 version upgrade and rollback

### Tested on:

MUG

### Test description:

[kyvernoupgrade160to163Logs.txt](https://github.com/user-attachments/files/16759492/kyvernoupgrade160to163Logs.txt)
[kyvernoupgrade163FreshInstllationLogs.txt](https://github.com/user-attachments/files/16759494/kyvernoupgrade163FreshInstllationLogs.txt)
[kyverno_1_6_3_to_1_6_4.txt](https://github.com/user-attachments/files/16759496/kyverno_1_6_3_to_1_6_4.txt)
[kyverno_1_5_5_to_1_6_3.txt](https://github.com/user-attachments/files/16759497/kyverno_1_5_5_to_1_6_3.txt)
