### PR TITLE
CASMSEC-499 : Fix CVEs in artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.3
+version: 1.6.4
 appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -110,7 +110,7 @@ kyverno:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.26.4
+        tag: 1.31.0
     clusterAdmissionReports:
       rbac:
         create: true
@@ -119,9 +119,9 @@ kyverno:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.26.4
+        tag: 1.31.0
   webhooksCleanup:
-    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.26.4
+    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
   buildKyvernoTrust:
     rbac:
       create: true
@@ -130,7 +130,7 @@ kyverno:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.26.4
+      tag: 1.31.0
       
   securityContext:
     seccompProfile: null


### PR DESCRIPTION
Summary and Scope
Bitnami kubectl 1.26.4 has been reported with many critical CVE's hence changing the charts to use higher version.

Testing
Kyverno installation, upgrade, rollback, policy listing, policy reports.

Tested on:
Surtur

Test description:
[CASMSEC-499-log.txt](https://github.com/user-attachments/files/17184105/CASMSEC-499-log.txt)
