### PR TITLE
CASMTRIAGE-7187: pre-install-check displays "failed to upgrade kyverno-policy chart"

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.4
+version: 1.6.5
 appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
@@ -23,13 +23,11 @@ spec:
             - '/bin/sh'
             - '-c'
             - |
-              echo "Running the Kyverno patch..."
               cd /usr/local/sbin && sh build-trust.sh
-              echo "Waiting for Kyverno deployment to complete rollout..."
+              # Waiting for Kyverno deployment to complete rollout
               kubectl rollout status deployment kyverno-admission-controller -n kyverno --timeout=60s
-              echo "Kyverno deployment has successfully rolled out."
+              # Waiting for 20 secs to avoid webhook timeouts. Known limitation in Kyverno w.r.t webhooks on 1.10.x.
               sleep 20
-              echo "slept for 20 secs"
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: build-kyverno-trust

--- a/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
@@ -21,9 +21,15 @@ spec:
           image: {{ .Values.kyverno.buildKyvernoTrust.image.registry }}/{{ .Values.kyverno.buildKyvernoTrust.image.repository }}:{{ .Values.kyverno.buildKyvernoTrust.image.tag }}
           command:
             - '/bin/sh'
-          args:
             - '-c'
-            - 'cd /usr/local/sbin && sh build-trust.sh '
+            - |
+              echo "Running the Kyverno patch..."
+              cd /usr/local/sbin && sh build-trust.sh
+              echo "Waiting for Kyverno deployment to complete rollout..."
+              kubectl rollout status deployment kyverno-admission-controller -n kyverno --timeout=60s
+              echo "Kyverno deployment has successfully rolled out."
+              sleep 20
+              echo "slept for 20 secs"
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: build-kyverno-trust


### PR DESCRIPTION
## Summary and Scope

Intermittently, Kyverno timeout issue is encountered during CSM upgrade. By introducing delay in post install hook we are introducing wait till Kyverno pods are stabilized and then going ahead with Kyverno policy upgrade.

## Testing

Kyverno Installation, Rollback, policy status, policy report, cluster policy status.

### Tested on:

MUG

### Test description:

[kyverno_logs_1_6_4_to_1_6_5.txt](https://github.com/user-attachments/files/17246145/kyverno_logs_1_6_4_to_1_6_5.txt)
[kyverno_logs_1_6_4_fresh_install.txt](https://github.com/user-attachments/files/17246201/kyverno_logs_1_6_4_fresh_install.txt)
[kyverno_logs_1_6_0_to_1_6_4.txt](https://github.com/user-attachments/files/17246202/kyverno_logs_1_6_0_to_1_6_4.txt)
[kyverno_logs_1_5_5_to_1_6_4.txt](https://github.com/user-attachments/files/17246204/kyverno_logs_1_5_5_to_1_6_4.txt)

