### PR TITLE
CASMSEC-499: Fix CVEs in artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.5
+version: 1.6.6
 appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -110,7 +110,7 @@ kyverno:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.31.0
+        tag: 1.31.1
     clusterAdmissionReports:
       rbac:
         create: true
@@ -119,9 +119,9 @@ kyverno:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.31.0
+        tag: 1.31.1
   webhooksCleanup:
-    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0
+    image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.1
   buildKyvernoTrust:
     rbac:
       create: true
@@ -130,7 +130,7 @@ kyverno:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.31.0
+      tag: 1.31.1
 
   securityContext:
     seccompProfile: null


### PR DESCRIPTION
## Summary and Scope

Bitnami kubectl 1.31.0 has been reported with many critical CVE's hence changing the charts to use higher version.

## Testing

Kyverno installation, upgrade, rollback, policy listing, policy reports.

### Tested on:

Fanta

### Test description:

[BitnamiUpgradeKyvernoTestLogs.txt](https://github.com/user-attachments/files/17538248/BitnamiUpgradeKyvernoTestLogs.txt)
