### PR TITLE
CASMTRIAGE-7187: pre-install-check displays "failed to upgrade kyverno-policy chart"

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.4
+version: 1.6.5
 appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
+++ b/charts/kyverno/templates/build-kyverno-trust/build-kyverno-trust.yaml
@@ -21,9 +21,13 @@ spec:
           image: {{ .Values.kyverno.buildKyvernoTrust.image.registry }}/{{ .Values.kyverno.buildKyvernoTrust.image.repository }}:{{ .Values.kyverno.buildKyvernoTrust.image.tag }}
           command:
             - '/bin/sh'
-          args:
             - '-c'
-            - 'cd /usr/local/sbin && sh build-trust.sh '
+            - |
+              cd /usr/local/sbin && sh build-trust.sh
+              # Waiting for Kyverno deployment to complete rollout
+              kubectl rollout status deployment kyverno-admission-controller -n kyverno --timeout=60s
+              # Waiting for 20 secs to avoid webhook timeouts. Known limitation in Kyverno w.r.t webhooks on 1.10.x.
+              sleep 20
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: build-kyverno-trust


### PR DESCRIPTION
## Summary and Scope

Intermittently, Kyverno timeout issue is encountered during CSM upgrade. By introducing delay in post install hook we are introducing wait till Kyverno pods are stabilized and then going ahead with Kyverno policy upgrade.

## Testing

Kyverno Installation, Rollback, policy status, policy report, cluster policy status.

### Tested on:

MUG

### Test description:

The same PR is raised to main branch. The details are @ https://github.com/Cray-HPE/cray-kyverno/pull/33