### PR TITLE
CASMSEC-505: Kyverno background policy scans are ignoring resourceFilters

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.6.5
+version: 1.6.6
 appVersion: v1.10.7
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -4,6 +4,9 @@ kyverno:
   upgrade:
   # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
     fromV2: true
+  features:
+    backgroundScan:
+      skipResourceFilters: false
   admissionController:
     rbac:
       create: true


### PR DESCRIPTION
## Summary and Scope

Kyverno generates policy reports for all the resources in the cluster currently, including the kube-system namespace as the resource filters are by default skipped in the upstream chart.

This PR sets the `skipResourceFilters: false` flag in the `values.yaml` under `features.backgroundScan` to enable resource filters. This reduces more than 100 kyverno baseline policy failures caused by the kube-system namespace.

## Issues and Related PRs

* Resolves [CASMSEC-505](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-505)
* Change will also be needed in `csm/1.6`

## Testing

### Tested on:

  * `Surtur`

### Test description:

[kyverno-skip-resource-filters-test.txt](https://github.com/user-attachments/files/18111977/kyverno-skip-resource-filters-test.txt)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

