### PR TITLE
CASMSEC-548: Fix CVE's in artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.31.0 

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.7.2
+version: 1.7.3
 appVersion: v1.13.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -103,22 +103,22 @@ kyverno:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.31.0
+        tag: 1.32.3
     clusterAdmissionReports:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.31.0
+        tag: 1.32.3
   webhooksCleanup:
     image: 
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.31.0
+      tag: 1.32.3
   policyReportsCleanup:
     image: 
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.31.0    
+      tag: 1.32.3    
   buildKyvernoTrust:
     rbac:
       create: true
@@ -127,7 +127,7 @@ kyverno:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.31.0
+      tag: 1.32.3
 
 
 


### PR DESCRIPTION
## Summary and Scope

Upgrading kubectl used in Kyverno to latest version as the current version is having critical vulnerability.


## Testing

Fresh installation, Upgrade of Kyverno.
Check all the policies including cluster policies and policy report.

### Tested on:

Starlord running CSM 1.7

### Test description:

[kyverno_1_7_2_to_1_7_3_upgrade_logs.txt](https://github.com/user-attachments/files/19864914/kyverno_1_7_2_to_1_7_3_upgrade_logs.txt)
[kyverno_1_7_3_fresh_install.txt](https://github.com/user-attachments/files/19864915/kyverno_1_7_3_fresh_install.txt)
