### PR TITLE
CASMSEC-511: Kyverno Upgrade Needed to support N-2 Policy

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.7.3
+version: 1.7.4
 appVersion: v1.13.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/hooks/_helper.tpl
+++ b/charts/kyverno/templates/hooks/_helper.tpl
@@ -1,0 +1,14 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "kyverno.pre-upgrade-job.name" -}}
+{{ template "kyverno.name" . }}-pre-upgrade-job
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "kyverno.pre-upgrade-job.sAccountName" -}}
+{{- if .Values.kyverno.deleteCrd.rbac.create -}}
+    {{ default (include "kyverno.pre-upgrade-job.name" .) .Values.kyverno.deleteCrd.rbac.saccount.name }}
+{{- else -}}
+    {{ required "A service account name is required when `rbac.create` is set to `false`" .Values.kyverno.deleteCrd.rbac.saccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/kyverno/templates/hooks/_helper.tpl
+++ b/charts/kyverno/templates/hooks/_helper.tpl
@@ -1,7 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{- define "kyverno.pre-upgrade-job.name" -}}
-{{ template "kyverno.name" . }}-pre-upgrade-job
+  kyverno-pre-upgrade-job
 {{- end -}}
 
 {{/* Create the name of the service account to use */}}

--- a/charts/kyverno/templates/hooks/clusterrole.yaml
+++ b/charts/kyverno/templates/hooks/clusterrole.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyverno.pre-upgrade-job.name" . }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+rules:
+- apiGroups: [""]
+  resourceNames:
+  - {{ include "kyverno.pre-upgrade-job.name" . }}
+  resources: [podsecuritypolicies]
+  verbs: [get, list, patch, create, delete, use]
+- apiGroups: [""]
+  resources: [configmaps]
+  verbs: [get, list, patch, create, delete]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: [customresourcedefinitions]
+  verbs: [get, list, patch, create, delete]
+- apiGroups: ["apps"]
+  resources: [deployments]
+  verbs: [get, list, patch, create, delete]
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [list, get, delete,create]

--- a/charts/kyverno/templates/hooks/clusterrole.yaml
+++ b/charts/kyverno/templates/hooks/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
   verbs: [get, list, patch, create, delete]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: [customresourcedefinitions]
-  verbs: [get, list, patch, create, delete]
+  verbs: [get, list, patch, create, delete, watch]
 - apiGroups: ["apps"]
   resources: [deployments]
   verbs: [get, list, patch, create, delete]

--- a/charts/kyverno/templates/hooks/clusterrolebinding.yaml
+++ b/charts/kyverno/templates/hooks/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyverno.pre-upgrade-job.name" . }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kyverno.pre-upgrade-job.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kyverno.pre-upgrade-job.sAccountName" . }}
+  namespace: {{ template "kyverno.namespace" . }}

--- a/charts/kyverno/templates/hooks/clusterrolebinding.yaml
+++ b/charts/kyverno/templates/hooks/clusterrolebinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kyverno.pre-upgrade-job.sAccountName" . }}
-  namespace: {{ template "kyverno.namespace" . }}
+  namespace: kyverno

--- a/charts/kyverno/templates/hooks/configmap.yaml
+++ b/charts/kyverno/templates/hooks/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: delete-crd
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "1"
+data:
+  deleteCRD.sh: |-
+    #!/bin/sh
+    kubectl delete crd $(kubectl get crd -A | grep -i kyverno | awk '{print $1}')

--- a/charts/kyverno/templates/hooks/configmap.yaml
+++ b/charts/kyverno/templates/hooks/configmap.yaml
@@ -8,4 +8,25 @@ metadata:
 data:
   deleteCRD.sh: |-
     #!/bin/sh
-    kubectl delete crd $(kubectl get crd -A | grep -i kyverno | awk '{print $1}')
+    NAMESPACE="kyverno"
+
+    PODS=$(kubectl get pods -n $NAMESPACE -l app.kubernetes.io/component=admission-controller --field-selector=status.phase=Running -o jsonpath='{.items[*].metadata.name}')
+
+    FIRST_POD=$(echo $PODS | awk '{print $1}')
+
+    IMAGE=$(kubectl get pod -n $NAMESPACE $FIRST_POD -o jsonpath="{.spec.containers[?(@.name=='kyverno')].image}")
+
+    if [ -n "$IMAGE" ]; then
+      VERSION=$(echo $IMAGE | awk -F: '{print $2}')
+    else
+      echo "Kyverno container image not found in pod: $FIRST_POD"
+    fi
+
+    if [ "$VERSION" = "v1.10.7" ]; then
+      echo "Version is v1.10.7 — attempting to delete CRDs..."
+      CRDS=$(kubectl get crd -A | grep -i kyverno | awk '{print $1}')
+      kubectl delete crd $CRDS
+      echo "CRDs deleted successfully."
+    else
+      echo "Kyverno version does not match v1.10.7 — no action taken."
+    fi

--- a/charts/kyverno/templates/hooks/pre-upgrade-job-svc-account.yaml
+++ b/charts/kyverno/templates/hooks/pre-upgrade-job-svc-account.yaml
@@ -1,0 +1,7 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "kyverno.pre-upgrade-job.sAccountName" . }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-20"

--- a/charts/kyverno/templates/hooks/pre-upgrade.yaml
+++ b/charts/kyverno/templates/hooks/pre-upgrade.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.kyverno.deleteCrd.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "kyverno.fullname" . }}-hook-pre-upgrade
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  template:
+    spec:
+      serviceAccount: {{ include "kyverno.pre-upgrade-job.sAccountName" . }}
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      restartPolicy: Never
+      containers:
+        - name: {{ include "kyverno.pre-upgrade-job.name" . }}
+          image: {{ .Values.kyverno.deleteCrd.image.registry }}/{{ .Values.kyverno.deleteCrd.image.repository }}:{{ .Values.kyverno.deleteCrd.image.tag }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cd /usr/local/sbin && sh deleteCRD.sh
+          volumeMounts:
+          - mountPath: /usr/local/sbin
+            name: delete-crd
+          securityContext:
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+      volumes:
+      - name: delete-crd
+        configMap:
+          name: delete-crd
+          defaultMode: 0755
+{{- end -}}

--- a/charts/kyverno/templates/hooks/pre-upgrade.yaml
+++ b/charts/kyverno/templates/hooks/pre-upgrade.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "kyverno.fullname" . }}-hook-pre-upgrade
+  name: {{ template "kyverno.pre-upgrade-job.name" . }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "10"

--- a/charts/kyverno/templates/hooks/pre-upgrade.yaml
+++ b/charts/kyverno/templates/hooks/pre-upgrade.yaml
@@ -35,5 +35,5 @@ spec:
       - name: delete-crd
         configMap:
           name: delete-crd
-          defaultMode: 0755
+          defaultMode: 0755          
 {{- end -}}

--- a/charts/kyverno/templates/hooks/pre-upgrade.yaml
+++ b/charts/kyverno/templates/hooks/pre-upgrade.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": hook-failed,before-hook-creation,hook-succeeded
 spec:
   template:
     spec:
@@ -35,5 +35,5 @@ spec:
       - name: delete-crd
         configMap:
           name: delete-crd
-          defaultMode: 0755          
+          defaultMode: 0755
 {{- end -}}

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -6,6 +6,7 @@ kyverno:
     fromV2: true
   crds:
     migration:
+      enabled: false
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/ghcr.io/kyverno/kyverno-cli
@@ -128,6 +129,16 @@ kyverno:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
       tag: 1.32.3
+  deleteCrd:
+    enabled: true
+    rbac:
+      create: true
+      saccount:
+        name: pre-upgrade-job
+    image:
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/docker.io/bitnami/kubectl
+      tag: 1.32.3      
 
 
 


### PR DESCRIPTION
## Summary and Scope

The changes consists of pre-upgrade hook for deleting old CRDs. The old CRDs are no longer compatible with new version and it is impossible to migrate. Also, we are not using CRDs to create any resources. This is the best possible solution during CSM 1.6 to CSM 1.7 upgrade to support changes in Kyverno policies and upstream Kyverno policies

## Testing

Fresh install  and upgrade.

### Tested on:

Starlord CSM 1.7 and Fanta CSM 1.6

### Test description:

Upgrade is successful on both Fanta and Starlord.
Fanta (CSM 1.6) needs Kyverno-policy and cray-kyverno-policies-upstream upgrade post Kyverno upgrade. This will the case even in the environment where we upgrade from CSM 1.6 to CSM 1.7.