### PR TITLE
CASMSEC-564: Fix CVE's in artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.32.3

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.7.4
+version: 1.7.5
 appVersion: v1.13.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -104,22 +104,22 @@ kyverno:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.32.3
+        tag: 1.33.1
     clusterAdmissionReports:
       image:
         registry: artifactory.algol60.net
         repository: csm-docker/stable/docker.io/bitnami/kubectl
-        tag: 1.32.3
+        tag: 1.33.1
   webhooksCleanup:
     image: 
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.32.3
+      tag: 1.33.1
   policyReportsCleanup:
     image: 
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.32.3    
+      tag: 1.33.1   
   buildKyvernoTrust:
     rbac:
       create: true
@@ -128,7 +128,7 @@ kyverno:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.32.3
+      tag: 1.33.1
   deleteCrd:
     enabled: true
     rbac:
@@ -138,7 +138,7 @@ kyverno:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/docker.io/bitnami/kubectl
-      tag: 1.32.3      
+      tag: 1.33.1      
 
 
 


### PR DESCRIPTION
## Summary and Scope

Current bitnami/kubectl version used in Kyverno is having critical vulnerability hence upgrading it to latest version.

## Testing

Kyverno upgrade and policy, cluster policy as well as policy report check.

### Tested on:

WASP

### Test description:

[kubectlCVEfixUpgradeTest.txt](https://github.com/user-attachments/files/20453761/kubectlCVEfixUpgradeTest.txt)
