### PR TITLE
CASMSEC-577: Errors displayed after csm only upgrade

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.7.5
+version: 1.7.6
 appVersion: v1.13.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management
@@ -21,7 +21,7 @@ maintainers:
   - name: ibrahim0809
     url: https://kyverno.io/
 engine: gotpl
-kubeVersion: ">=1.25.0-0"
+kubeVersion: ">=1.24.0-0"
 annotations:
   artifacthub.io/images: |-
     - name: kyverno


### PR DESCRIPTION
## Summary and Scope

This change helps to upgrade Kyverno without PSPs at k8s 1.24 stage which is currently happening for CSM 1.7.0 release.

## Testing

Upgrade testing

### Tested on:

Molly

### Test description:

[mollyTestLogs.txt](https://github.com/user-attachments/files/20915172/mollyTestLogs.txt)
