### PR TITLE
CAST-38972: cray-kyverno deployment timeout

### DIFF
--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: cray-kyverno
-version: 1.7.6
+version: 1.7.7
 appVersion: v1.13.4
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png
 description: Kubernetes Native Policy Management

--- a/charts/kyverno/templates/hooks/pre-upgrade.yaml
+++ b/charts/kyverno/templates/hooks/pre-upgrade.yaml
@@ -24,6 +24,9 @@ spec:
             - -c
             - |
               cd /usr/local/sbin && sh deleteCRD.sh
+              # Waiting to avoid webhook timeouts.
+              echo "Pre-upgrade delay: {{ .Values.kyverno.preUpgradeDelay }} seconds"
+              sleep {{ .Values.kyverno.preUpgradeDelay }}
           volumeMounts:
           - mountPath: /usr/local/sbin
             name: delete-crd

--- a/charts/kyverno/values.yaml
+++ b/charts/kyverno/values.yaml
@@ -4,6 +4,7 @@ kyverno:
   upgrade:
   # -- Upgrading from v2 to v3 is not allowed by default, set this to true once changes have been reviewed.
     fromV2: true
+  preUpgradeDelay: 30
   crds:
     migration:
       enabled: false


### PR DESCRIPTION
## Summary and Scope

Customer reported there was a webhook timeout encountered in one of their upgrade during pre-upgrade stage of Kyverno. This was resolved by increasing the timeout. The same is incorporated in Kyverno.


## Testing

Tested Fresh install and Upgrade of Kyverno

### Tested on:

Drax

### Test description
[Kyverno177upgrade.txt](https://github.com/user-attachments/files/23750220/Kyverno177upgrade.txt)
[kyverno-1_7_7_fresh_install.txt](https://github.com/user-attachments/files/23750191/kyverno-1_7_7_fresh_install.txt)
